### PR TITLE
Kernel: Revert #630,Manual hooks and SUSFS are compiled into the kernel simultaneously.

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -43,7 +43,7 @@ config KPM
 
 config KSU_MANUAL_HOOK
 	bool "Hook KernelSU manually"
-	depends on KSU != m && !KSU_SUSFS
+	depends on KSU != m
 	help
 	  If enabled, Hook required KernelSU syscalls with manually-patched function.
 


### PR DESCRIPTION
***
**Revert [#630](https://github.com/ReSukiSU/ReSukiSU/commit/ad90267593bd98c7a5c0f9fc8589b9619d77355c)**  
If you're compiling an older kernel and using Susfs v2.0.0, then without manual hooks, KSU will be completely disabled. Everything becomes meaningless.   
You shouldn't prevent manual hooks and SUSFS from coexisting.
***