### PR TITLE
SUSFS: kernel: Various fixes for SUS_PATH and SUS_MOUNT, plus

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -106,7 +106,7 @@ config KSU_SUSFS
 config KSU_SUSFS_SUS_PATH
     bool "Enable to hide suspicious path (NOT recommended)"
     depends on KSU_SUSFS
-    default y
+    default n
     help
         - Allow hiding the user-defined path and all its sub-paths from various system calls.
         - Includes temp fix for the leaks of app path in /sdcard/Android/data directory.
@@ -126,7 +126,7 @@ config KSU_SUSFS_SUS_MOUNT
 config KSU_SUSFS_SUS_KSTAT
     bool "Enable to spoof suspicious kstat"
     depends on KSU_SUSFS
-    default y
+    default n
     help
         - Allow spoofing the kstat of user-defined file/directory.
         - Effective only on zygote spawned user app process.
@@ -165,7 +165,7 @@ config KSU_SUSFS_SPOOF_CMDLINE_OR_BOOTCONFIG
 config KSU_SUSFS_OPEN_REDIRECT
     bool "Enable to redirect a path to be opened with another path (experimental)"
     depends on KSU_SUSFS
-    default y
+    default n
     help
         - Allow redirecting a target path to be opened with another user-defined path.
         - Effective only on processes with uid < 2000.


### PR DESCRIPTION
 overall code improvement and optimization

- Remove the need of flagging /sdcard or /sdcard/Android/data, so we can just do "ksu_susfs add_sus_path </sdcard/TWRP|/sdcard/Android/data/com.example.myapp" for example. To completely prevent unicode exploit users can pick up the patches from here if needed: https://github.com/WildKernels/kernel_patches/blob/main/common/unicode_bypass_fix_6.1%2B.patch / https://github.com/WildKernels/kernel_patches/blob/main/common/unicode_bypass_fix_6.1-.patch

- To deal with FUSE based path, first we check for the inode->i_sb->s_magic, if its magic is FUSE, then we use get_fuse_inode(inode) API to retrieve its fuse inode and flag SUS_PATH on fi->i_mapping->flags.

- Remove overall overheads as we can now get rid of linked list to check for sus path in "/sdcard" and "/sdcard/Android/data", however, for add_sus_path_loop we still need it. But we can consider to use userspace inotify to watch specific paths and pass list of paths to add_sus_path when needed, that will reduce the overheads of iterating the SUS_PATH_LOOP linked list every time zygote spawns a new process.

- Apply only on proc with uid >= 10000 and marked umounted.

- Fixed deadlock and race issues, see 4803afa7 and 068ebeb3

- d_lookup(), __d_lookup() and __d_lookup_rcu() will just return NULL if no dcache is found, so we can just dput() the dentry and set it to NULL, no need to do extra lookup with fake qstr.

- Use d_lookup_done(dentry) to make sure "dentry->d_flags &= ~DCACHE_PAR_LOOKUP" and "dentry->d_wait = NULL" if it is found sus, and re-use DECLARE_WAIT_QUEUE_HEAD_ONSTACK(wq);

- Fix several race issues by using proper locks: down_read(&namespace_sem); // needed when manipulating mnt_namespace lock_ns_list(mnt_ns); // needed when traversing mnt_ns->list lock_mount_hash(); // needed when modifying mount