### PR TITLE
workflow: clippy : dont use cross

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -22,7 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - run: rustup update stable
+      - run: |
+          rustup update stable
+          rustup target install aarch64-linux-android armv7-linux-androideabi x86_64-linux-android
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: userspace/ksud


### PR DESCRIPTION
Use cargo-ndk to avoid using an outdated version of Cross.