### PR TITLE
kernel & KernelSU: Implement SRCU for SUS_PATH; Deprecate...

### DIFF
--- a/kernel/supercalls.c
+++ b/kernel/supercalls.c
@@ -1046,14 +1046,6 @@ int ksu_handle_sys_reboot(int magic1, int magic2, unsigned int cmd,
             susfs_add_sus_path_loop(arg);
             return 0;
         }
-        if (cmd == CMD_SUSFS_SET_ANDROID_DATA_ROOT_PATH) {
-            susfs_set_i_state_on_external_dir(arg);
-            return 0;
-        }
-        if (cmd == CMD_SUSFS_SET_SDCARD_ROOT_PATH) {
-            susfs_set_i_state_on_external_dir(arg);
-            return 0;
-        }
 #endif //#ifdef CONFIG_KSU_SUSFS_SUS_PATH
 #ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
         if (cmd == CMD_SUSFS_HIDE_SUS_MNTS_FOR_NON_SU_PROCS) {


### PR DESCRIPTION
kernel & KernelSU: Implement SRCU for SUS_PATH; Deprecate CMD_SUSFS_SET_ANDROID_DATA_ROOT_PATH and CMD_SUSFS_SET_SDCARD_ROOT_PATH

- The way we use RSCU instead RCU for SUS_PATH is because running kern_path() within RCU CS will trigger kernel bugs since it will sleep and wait, so here we need to use the sleepable RCU.

- Remove deprcated CMDs: "CMD_SUSFS_SET_ANDROID_DATA_ROOT_PATH" and "CMD_SUSFS_SET_SDCARD_ROOT_PATH"