### PR TITLE
manager: enable ABI splits in manager app

### DIFF
--- a/manager/app/build.gradle.kts
+++ b/manager/app/build.gradle.kts
@@ -133,6 +133,15 @@ android {
         }
     }
 
+    splits {
+        abi {
+            isEnable = true
+            reset()
+            include("arm64-v8a", "x86_64", "armeabi-v7a")
+            isUniversalApk = true
+        }
+    }
+
     lint {
         abortOnError = true
         checkReleaseBuilds = false


### PR DESCRIPTION
This change enables ABI splits for `arm64-v8a`, `x86_64`, and `armeabi-v7a`, and enables the generation of a universal APK.

Trying to make user can use a size minimal manager