### PR TITLE
CI: Migrate telethon to python-telegram-bot & message handling improvements

### DIFF
--- a/.github/workflows/build-manager.yml
+++ b/.github/workflows/build-manager.yml
@@ -219,8 +219,6 @@ jobs:
           CHAT_ID: ${{ vars.CHAT_ID }}
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
           MESSAGE_THREAD_ID: ${{ steps.determine.outputs.topicid }}
-          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-          COMMIT_URL: ${{ github.event.head_commit.url }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           TITLE: ${{ steps.determine.outputs.title }}
           BRANCH: ${{ github.ref_name }}

--- a/scripts/ksubot.py
+++ b/scripts/ksubot.py
@@ -23,7 +23,7 @@ try:
         i = len(commits)
         for commit in commits[::-1]:
             msg_line = commit['message'].split('\n')
-            msg = msg_line[0].strip()
+            msg = commit['message'].strip()
             msg += ' by ' + commit['author']['username']
             if len(msg) + 1 + len(commit_message) > 3192:
                 commit_message = f'(other {i} commits)\n{commit_message}'


### PR DESCRIPTION
- Migrate telethon to python-telegram-bot

In our actions run,Upload apks to telegram by telethon wasted a lot of time,especially now we were splited apk for different architecture.

- Message handling improvements

Split upload release and debug apks,and if captain was too long,will send a separate message.

Also,make COMMIT MESSAGE and COMMIT URL dynamic generate by GITHUB_EVENT_PATH,