### PR TITLE
manager: fix blank screen glitch during back navigation on Android 13 and below

### DIFF
--- a/manager/app/src/main/java/com/resukisu/resukisu/ui/MainActivity.kt
+++ b/manager/app/src/main/java/com/resukisu/resukisu/ui/MainActivity.kt
@@ -316,16 +316,18 @@ class MainActivity : ComponentActivity() {
                         val navigationScope = rememberCoroutineScope()
                         val onBack: (() -> Unit) -> Unit = { callBack ->
                             navigationScope.launch {
-                                exitingPageKey = navigator.current().toString()
-                                exitAnimatable.animateTo(
-                                    targetValue = 1f,
-                                    animationSpec = tween(
-                                        durationMillis = 200,
-                                        easing = FastOutSlowInEasing
+                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                                    exitingPageKey = navigator.current().toString()
+                                    exitAnimatable.animateTo(
+                                        targetValue = 1f,
+                                        animationSpec = tween(
+                                            durationMillis = 200,
+                                            easing = FastOutSlowInEasing
+                                        )
                                     )
-                                )
+                                    exitAnimatable.snapTo(0f)
+                                }
 
-                                exitAnimatable.snapTo(0f)
                                 callBack()
 
                                 when (val top = navigator.current()) {


### PR DESCRIPTION
Previously, when users navigated back from a secondary page using the system back button or swipe gesture on Android 13 and older devices, a visual glitch occurred where the screen would temporarily display a blank background.

This issue was caused by a custom predictive back animation, which requires Android 14's pre-rendering capabilities, was applied globally. To resolve this, the animation is now restricted to devices running Android 14 and above.