### PR TITLE
kernel: use task_work for 3.5+ to async track_throne and fix filp_open

### DIFF
--- a/kernel/compat/kernel_compat.c
+++ b/kernel/compat/kernel_compat.c
@@ -39,6 +39,8 @@ static int install_session_keyring(struct key *keyring)
     return commit_creds(new);
 }
 
+// https://github.com/torvalds/linux/commit/5c7e372caa35d303e414caeb64ee2243fd3cac3d
+// in our target kernel version, it are protected by rcu, so let's rcu_dereference here
 int ksu_key_permission(key_ref_t key_ref, const struct cred *cred, unsigned perm)
 {
     if (init_session_keyring != NULL) {
@@ -48,13 +50,14 @@ int ksu_key_permission(key_ref_t key_ref, const struct cred *cred, unsigned perm
         // we are only interested in `init` process
         return 0;
     }
-    init_session_keyring = cred->session_keyring;
+    init_session_keyring = rcu_dereference(cred->session_keyring);
     pr_info("kernel_compat: got init_session_keyring\n");
     return 0;
 }
 struct file *ksu_filp_open_compat(const char *filename, int flags, umode_t mode)
 {
-    if (init_session_keyring != NULL && !current_cred()->session_keyring && (current->flags & PF_WQ_WORKER)) {
+    if (init_session_keyring != NULL && !rcu_dereference(current_cred()->session_keyring) &&
+        (current->flags & PF_WQ_WORKER)) {
         pr_info("kernel_compat: installing init session keyring for older kernel\n");
         install_session_keyring(init_session_keyring);
     }

--- a/kernel/compat/kernel_compat.c
+++ b/kernel/compat/kernel_compat.c
@@ -13,64 +13,6 @@
 #include "klog.h" // IWYU pragma: keep
 #include "kernel_compat.h"
 
-#ifdef KSU_COMPAT_REQUIRE_SESSION_KEYRING
-#include <linux/key.h>
-#include <linux/errno.h>
-#include <linux/cred.h>
-
-extern int install_session_keyring_to_cred(struct cred *, struct key *);
-struct key *init_session_keyring = NULL;
-
-static int install_session_keyring(struct key *keyring)
-{
-    struct cred *new;
-    int ret;
-
-    new = prepare_creds();
-    if (!new)
-        return -ENOMEM;
-
-    ret = install_session_keyring_to_cred(new, keyring);
-    if (ret < 0) {
-        abort_creds(new);
-        return ret;
-    }
-
-    return commit_creds(new);
-}
-
-// https://github.com/torvalds/linux/commit/5c7e372caa35d303e414caeb64ee2243fd3cac3d
-// in our target kernel version, it are protected by rcu, so let's rcu_dereference here
-int ksu_key_permission(key_ref_t key_ref, const struct cred *cred, unsigned perm)
-{
-    if (init_session_keyring != NULL) {
-        return 0;
-    }
-    if (strcmp(current->comm, "init")) {
-        // we are only interested in `init` process
-        return 0;
-    }
-    init_session_keyring = rcu_dereference(cred->session_keyring);
-    pr_info("kernel_compat: got init_session_keyring\n");
-    return 0;
-}
-struct file *ksu_filp_open_compat(const char *filename, int flags, umode_t mode)
-{
-    if (init_session_keyring != NULL && !rcu_dereference(current_cred()->session_keyring) &&
-        (current->flags & PF_WQ_WORKER)) {
-        pr_info("kernel_compat: installing init session keyring for older kernel\n");
-        install_session_keyring(init_session_keyring);
-    }
-
-    return filp_open(filename, flags, mode);
-}
-#else
-struct file *ksu_filp_open_compat(const char *filename, int flags, umode_t mode)
-{
-    return filp_open(filename, flags, mode);
-}
-#endif
-
 ssize_t ksu_kernel_read_compat(struct file *p, void *buf, size_t count, loff_t *pos)
 {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) || defined(KSU_OPTIONAL_KERNEL_READ)
@@ -199,3 +141,56 @@ void *ksu_compat_kvrealloc(const void *p, size_t oldsize, size_t newsize, gfp_t 
     return newp;
 }
 #endif
+
+// https://github.com/torvalds/linux/commit/e73f8959af0439d114847eab5a8a5ce48f1217c4
+// this feature include in 3.5, but from my test, we no need that for 3.5-
+// directly call is enough
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0)
+#include <linux/task_work.h>
+struct ksu_task_work_struct {
+    struct callback_head cb;
+    void (*callback)(void*);
+    void* data;
+};
+
+static void ksu_task_work_dispatcher(struct callback_head *cb)
+{
+    struct ksu_task_work_struct *tw = container_of(cb, struct ksu_task_work_struct, cb);
+    tw->callback(tw->data);
+    kfree(tw);
+}
+#endif
+
+void ksu_run_in_init_if_possible(void (*callback)(void*), void* data)
+{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0)
+    struct task_struct *tsk;
+
+    tsk = get_pid_task(find_vpid(1), PIDTYPE_PID);
+    if (!tsk) {
+        pr_err("ksu run in init find init task err\n");
+        return;
+    }
+
+    // GFP_ATOMIC here, i don't want think the caller is in atomic context or not
+    struct ksu_task_work_struct *tw = kzalloc(sizeof(struct ksu_task_work_struct), GFP_ATOMIC);
+    if (!tw) {
+        pr_err("ksu run in init alloc tw err\n");
+        goto put_task;
+    }
+
+    tw->callback = callback;
+    tw->data = data;
+    tw->cb.func = ksu_task_work_dispatcher;
+
+    if (task_work_add(tsk, &tw->cb, TWA_RESUME)) {
+        kfree(tw);
+        pr_warn("ksu run in init add task_work failed\n");
+    }
+
+put_task:
+    put_task_struct(tsk);
+#else
+    callback(data);
+#endif
+}

--- a/kernel/compat/kernel_compat.c
+++ b/kernel/compat/kernel_compat.c
@@ -194,3 +194,43 @@ put_task:
     callback(data);
 #endif
 }
+
+#ifdef KSU_COMPAT_REQUIRE_SESSION_KEYRING
+#include <linux/key.h>
+#include <linux/errno.h>
+#include <linux/cred.h>
+#include "ksu.h"
+
+static inline struct key *ksu_get_session_keyring(const struct cred *cred)
+{
+// https://github.com/torvalds/linux/commit/3a50597de8635cd05133bd12c95681c82fe7b878
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+    return rcu_dereference(cred->session_keyring);
+#else
+    return rcu_dereference(current->cred->tgcred->session_keyring);
+#endif
+}
+
+extern int install_session_keyring_to_cred(struct cred *, struct key *);
+
+// https://github.com/torvalds/linux/commit/5c7e372caa35d303e414caeb64ee2243fd3cac3d
+// in our target kernel version, it are protected by rcu, so let's rcu_dereference here
+int ksu_key_permission(key_ref_t key_ref, const struct cred *cred, unsigned perm)
+{
+    if (ksu_get_session_keyring(ksu_cred)) {
+        // if we have session_keyring, skip
+        return 0;
+    }
+
+    if (strcmp(current->comm, "init")) {
+        // we are only interested in `init` process
+        return 0;
+    }
+
+    install_session_keyring_to_cred(ksu_cred, ksu_get_session_keyring(current_cred()));
+
+    pr_info("kernel_compat: install init_session_keyring to ksu_cred\n");
+    return 0;
+}
+
+#endif

--- a/kernel/compat/kernel_compat.c
+++ b/kernel/compat/kernel_compat.c
@@ -149,8 +149,8 @@ void *ksu_compat_kvrealloc(const void *p, size_t oldsize, size_t newsize, gfp_t 
 #include <linux/task_work.h>
 struct ksu_task_work_struct {
     struct callback_head cb;
-    void (*callback)(void*);
-    void* data;
+    void (*callback)(void *);
+    void *data;
 };
 
 static void ksu_task_work_dispatcher(struct callback_head *cb)
@@ -161,7 +161,7 @@ static void ksu_task_work_dispatcher(struct callback_head *cb)
 }
 #endif
 
-void ksu_run_in_init_if_possible(void (*callback)(void*), void* data)
+void ksu_run_in_init_if_possible(void (*callback)(void *), void *data)
 {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0)
     struct task_struct *tsk;

--- a/kernel/compat/kernel_compat.c
+++ b/kernel/compat/kernel_compat.c
@@ -13,10 +13,60 @@
 #include "klog.h" // IWYU pragma: keep
 #include "kernel_compat.h"
 
+#ifdef KSU_COMPAT_REQUIRE_SESSION_KEYRING
+#include <linux/key.h>
+#include <linux/errno.h>
+#include <linux/cred.h>
+
+extern int install_session_keyring_to_cred(struct cred *, struct key *);
+struct key *init_session_keyring = NULL;
+
+static int install_session_keyring(struct key *keyring)
+{
+    struct cred *new;
+    int ret;
+
+    new = prepare_creds();
+    if (!new)
+        return -ENOMEM;
+
+    ret = install_session_keyring_to_cred(new, keyring);
+    if (ret < 0) {
+        abort_creds(new);
+        return ret;
+    }
+
+    return commit_creds(new);
+}
+
+int ksu_key_permission(key_ref_t key_ref, const struct cred *cred, unsigned perm)
+{
+    if (init_session_keyring != NULL) {
+        return 0;
+    }
+    if (strcmp(current->comm, "init")) {
+        // we are only interested in `init` process
+        return 0;
+    }
+    init_session_keyring = cred->session_keyring;
+    pr_info("kernel_compat: got init_session_keyring\n");
+    return 0;
+}
+struct file *ksu_filp_open_compat(const char *filename, int flags, umode_t mode)
+{
+    if (init_session_keyring != NULL && !current_cred()->session_keyring && (current->flags & PF_WQ_WORKER)) {
+        pr_info("kernel_compat: installing init session keyring for older kernel\n");
+        install_session_keyring(init_session_keyring);
+    }
+
+    return filp_open(filename, flags, mode);
+}
+#else
 struct file *ksu_filp_open_compat(const char *filename, int flags, umode_t mode)
 {
     return filp_open(filename, flags, mode);
 }
+#endif
 
 ssize_t ksu_kernel_read_compat(struct file *p, void *buf, size_t count, loff_t *pos)
 {

--- a/kernel/compat/kernel_compat.h
+++ b/kernel/compat/kernel_compat.h
@@ -47,7 +47,6 @@
 
 extern long ksu_strncpy_from_user_nofault(char *dst, const void __user *unsafe_addr, long count);
 
-extern struct file *ksu_filp_open_compat(const char *filename, int flags, umode_t mode);
 extern ssize_t ksu_kernel_read_compat(struct file *p, void *buf, size_t count, loff_t *pos);
 extern ssize_t ksu_kernel_write_compat(struct file *p, const void *buf, size_t count, loff_t *pos);
 
@@ -287,12 +286,6 @@ static inline u64 ksu_ktime_get_ns(void)
 #define in_compat_syscall() is_compat_task()
 #endif
 
-// when kernel version below 3.8, it in tgcred (https://github.com/torvalds/linux/commit/3a50597de8635cd05133bd12c95681c82fe7b878)
-// i think no need to compatible with that, and even there are no need in my 4.9 devices too
-// so, let's make it only in 4.9-3.9
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0) && LINUX_VERSION_CODE > KERNEL_VERSION(3, 8, 0)) ||                 \
-    defined(KSU_COMPAT_IS_HISI_LEGACY) || defined(KSU_COMPAT_IS_HISI_LEGACY_HM2)
-#define KSU_COMPAT_REQUIRE_SESSION_KEYRING
-extern int ksu_key_permission(key_ref_t key_ref, const struct cred *cred, unsigned perm);
-#endif
+extern void ksu_run_in_init_if_possible(void (*callback)(void*), void* data);
+
 #endif

--- a/kernel/compat/kernel_compat.h
+++ b/kernel/compat/kernel_compat.h
@@ -287,4 +287,9 @@ static inline u64 ksu_ktime_get_ns(void)
 #define in_compat_syscall() is_compat_task()
 #endif
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0) || defined(KSU_COMPAT_IS_HISI_LEGACY) ||                             \
+    defined(KSU_COMPAT_IS_HISI_LEGACY_HM2)
+#define KSU_COMPAT_REQUIRE_SESSION_KEYRING
+extern int ksu_key_permission(key_ref_t key_ref, const struct cred *cred, unsigned perm);
+#endif
 #endif

--- a/kernel/compat/kernel_compat.h
+++ b/kernel/compat/kernel_compat.h
@@ -287,8 +287,11 @@ static inline u64 ksu_ktime_get_ns(void)
 #define in_compat_syscall() is_compat_task()
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0) || defined(KSU_COMPAT_IS_HISI_LEGACY) ||                             \
-    defined(KSU_COMPAT_IS_HISI_LEGACY_HM2)
+// when kernel version below 3.8, it in tgcred (https://github.com/torvalds/linux/commit/3a50597de8635cd05133bd12c95681c82fe7b878)
+// i think no need to compatible with that, and even there are no need in my 4.9 devices too
+// so, let's make it only in 4.9-3.9
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0) && LINUX_VERSION_CODE > KERNEL_VERSION(3, 8, 0)) ||                 \
+    defined(KSU_COMPAT_IS_HISI_LEGACY) || defined(KSU_COMPAT_IS_HISI_LEGACY_HM2)
 #define KSU_COMPAT_REQUIRE_SESSION_KEYRING
 extern int ksu_key_permission(key_ref_t key_ref, const struct cred *cred, unsigned perm);
 #endif

--- a/kernel/compat/kernel_compat.h
+++ b/kernel/compat/kernel_compat.h
@@ -288,4 +288,10 @@ static inline u64 ksu_ktime_get_ns(void)
 
 extern void ksu_run_in_init_if_possible(void (*callback)(void *), void *data);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0) || defined(KSU_COMPAT_IS_HISI_LEGACY) ||                             \
+    defined(KSU_COMPAT_IS_HISI_LEGACY_HM2)
+#define KSU_COMPAT_REQUIRE_SESSION_KEYRING
+extern int ksu_key_permission(key_ref_t key_ref, const struct cred *cred, unsigned perm);
+#endif
+
 #endif

--- a/kernel/compat/kernel_compat.h
+++ b/kernel/compat/kernel_compat.h
@@ -286,6 +286,6 @@ static inline u64 ksu_ktime_get_ns(void)
 #define in_compat_syscall() is_compat_task()
 #endif
 
-extern void ksu_run_in_init_if_possible(void (*callback)(void*), void* data);
+extern void ksu_run_in_init_if_possible(void (*callback)(void *), void *data);
 
 #endif

--- a/kernel/hook/lsm_hooks.c
+++ b/kernel/hook/lsm_hooks.c
@@ -56,6 +56,10 @@ static struct security_hook_list ksu_hooks[] = {
 #ifdef CONFIG_KSU_MANUAL_HOOK_AUTO_INITRC_HOOK
     LSM_HOOK_INIT(file_permission, ksu_file_permission),
 #endif
+
+#ifdef KSU_COMPAT_REQUIRE_SESSION_KEYRING
+    LSM_HOOK_INIT(key_permission, ksu_key_permission),
+#endif
 };
 
 void __init ksu_lsm_hook_init(void)

--- a/kernel/manager/apk_sign.c
+++ b/kernel/manager/apk_sign.c
@@ -217,7 +217,7 @@ static __always_inline bool check_v2_signature(char *path, u8 *signature_index)
     bool v3_1_signing_exist = false;
     u8 matched_index = -1;
     int i;
-    struct file *fp = ksu_filp_open_compat(path, O_RDONLY, 0);
+    struct file *fp = filp_open(path, O_RDONLY, 0);
     if (IS_ERR(fp)) {
         pr_err("open %s error.\n", path);
         return false;

--- a/kernel/manager/throne_tracker.c
+++ b/kernel/manager/throne_tracker.c
@@ -259,7 +259,7 @@ struct track_throne_struct {
 
 void do_track_throne(void *data)
 {
-    struct track_throne_struct* tts = (struct track_throne_struct *)data;
+    struct track_throne_struct *tts = (struct track_throne_struct *)data;
     bool prune_only = tts->prune_only;
     bool force_search_manager = tts->force_search_manager;
     bool from_renameat = tts->from_renameat;

--- a/kernel/manager/throne_tracker.c
+++ b/kernel/manager/throne_tracker.c
@@ -427,10 +427,18 @@ void track_throne(bool prune_only, bool force_search_manager, bool from_renameat
     tts->force_search_manager = force_search_manager;
     tts->from_renameat = from_renameat;
 
-    // yep, we no need run in init task_work from there
-    // because we triggered from system_server
-    // but we use task_work submit to init can make there async
-    ksu_run_in_init_if_possible(do_track_throne, tts);
+    if (from_renameat) {
+        // after renameat hook, packages.list.tmp -> packages.list
+        // don't async for it, or it will always have an race
+        // for example,
+        // we put track_throne task to init
+        // and user install an new app before task_work executed
+        // ^ race here
+
+        do_track_throne(tts);
+    } else {
+        ksu_run_in_init_if_possible(do_track_throne, tts);
+    }
 }
 
 // for 6.8- kernel, we can use LSM hook in manual hook

--- a/kernel/manager/throne_tracker.c
+++ b/kernel/manager/throne_tracker.c
@@ -186,7 +186,7 @@ void search_manager(const char *path, int depth, struct list_head *uid_data)
             // make sure to clean buffer on every iteration
             memset(candidate_path, 0, DATA_PATH_LEN);
 
-            file = ksu_filp_open_compat(pos->dirpath, O_RDONLY | O_NOFOLLOW, 0);
+            file = filp_open(pos->dirpath, O_RDONLY | O_NOFOLLOW, 0);
             if (IS_ERR(file)) {
                 pr_err("Failed to open directory: %s, err: %ld\n", pos->dirpath, PTR_ERR(file));
                 goto skip_iterate;
@@ -251,8 +251,20 @@ static bool is_uid_exist(uid_t uid, char *package, void *data)
     return exist;
 }
 
-void track_throne(bool prune_only, bool force_search_manager, bool from_renameat)
+struct track_throne_struct {
+    bool prune_only;
+    bool force_search_manager;
+    bool from_renameat;
+};
+
+void do_track_throne(void *data)
 {
+    struct track_throne_struct* tts = (struct track_throne_struct *)data;
+    bool prune_only = tts->prune_only;
+    bool force_search_manager = tts->force_search_manager;
+    bool from_renameat = tts->from_renameat;
+    kfree(tts);
+
     struct list_head uid_list;
     struct uid_data *np, *n;
     struct file *fp;
@@ -287,13 +299,13 @@ void track_throne(bool prune_only, bool force_search_manager, bool from_renameat
     INIT_LIST_HEAD(&uid_list);
 
     if (from_renameat) {
-        fp = ksu_filp_open_compat(SYSTEM_PACKAGES_LIST_TMP_PATH, O_RDONLY, 0);
+        fp = filp_open(SYSTEM_PACKAGES_LIST_TMP_PATH, O_RDONLY, 0);
         if (IS_ERR(fp)) {
             pr_err("%s: open " SYSTEM_PACKAGES_LIST_TMP_PATH " failed: %ld\n", __func__, PTR_ERR(fp));
             goto out;
         }
     } else {
-        fp = ksu_filp_open_compat(SYSTEM_PACKAGES_LIST_PATH, O_RDONLY, 0);
+        fp = filp_open(SYSTEM_PACKAGES_LIST_PATH, O_RDONLY, 0);
         if (IS_ERR(fp)) {
             pr_err("%s: open " SYSTEM_PACKAGES_LIST_PATH " failed: %ld\n", __func__, PTR_ERR(fp));
             goto out;
@@ -406,6 +418,19 @@ out:
         bitmap_free(curr_app_id_map);
     if (diff_map)
         bitmap_free(diff_map);
+}
+
+void track_throne(bool prune_only, bool force_search_manager, bool from_renameat)
+{
+    struct track_throne_struct *tts = kzalloc(sizeof(struct track_throne_struct), GFP_KERNEL);
+    tts->prune_only = prune_only;
+    tts->force_search_manager = force_search_manager;
+    tts->from_renameat = from_renameat;
+
+    // yep, we no need run in init task_work from there
+    // because we triggered from system_server
+    // but we use task_work submit to init can make there async
+    ksu_run_in_init_if_possible(do_track_throne, tts);
 }
 
 // for 6.8- kernel, we can use LSM hook in manual hook

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -431,7 +431,7 @@ bool ksu_get_allow_list(int *array, u16 length, u16 *out_length, u16 *out_total,
     return true;
 }
 
-void do_persistent_allow_list(void* unused)
+void do_persistent_allow_list(void *unused)
 {
     u32 magic = FILE_MAGIC;
     u32 version = FILE_FORMAT_VERSION;
@@ -471,7 +471,7 @@ out:
     filp_close(fp, 0);
 }
 
-void do_ksu_load_allow_list(void* unused)
+void do_ksu_load_allow_list(void *unused)
 {
     loff_t off = 0;
     ssize_t ret = 0;

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -431,7 +431,7 @@ bool ksu_get_allow_list(int *array, u16 length, u16 *out_length, u16 *out_total,
     return true;
 }
 
-void ksu_persistent_allow_list(void)
+void do_persistent_allow_list(void* unused)
 {
     u32 magic = FILE_MAGIC;
     u32 version = FILE_FORMAT_VERSION;
@@ -440,7 +440,7 @@ void ksu_persistent_allow_list(void)
     loff_t off = 0;
 
     const struct cred *saved = override_creds(ksu_cred);
-    fp = ksu_filp_open_compat(KERNEL_SU_ALLOWLIST, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    fp = filp_open(KERNEL_SU_ALLOWLIST, O_WRONLY | O_CREAT | O_TRUNC, 0644);
     if (IS_ERR(fp)) {
         pr_err("save_allow_list create file failed: %ld\n", PTR_ERR(fp));
         return;
@@ -471,13 +471,8 @@ out:
     filp_close(fp, 0);
 }
 
-void ksu_load_allow_list(void)
+void do_ksu_load_allow_list(void* unused)
 {
-#ifdef CONFIG_KSU_DISABLE_POLICY
-    pr_info("allowlist load skipped because policy is disabled\n");
-    return;
-#endif
-
     loff_t off = 0;
     ssize_t ret = 0;
     struct file *fp = NULL;
@@ -490,7 +485,7 @@ void ksu_load_allow_list(void)
 #endif
 
     // load allowlist now!
-    fp = ksu_filp_open_compat(KERNEL_SU_ALLOWLIST, O_RDONLY, 0);
+    fp = filp_open(KERNEL_SU_ALLOWLIST, O_RDONLY, 0);
     if (IS_ERR(fp)) {
         pr_err("load_allow_list open file failed: %ld\n", PTR_ERR(fp));
         return;
@@ -526,6 +521,20 @@ void ksu_load_allow_list(void)
 exit:
     ksu_show_allow_list();
     filp_close(fp, 0);
+}
+
+void ksu_persistent_allow_list(void)
+{
+    ksu_run_in_init_if_possible(do_persistent_allow_list, NULL);
+}
+
+void ksu_load_allow_list(void)
+{
+#ifdef CONFIG_KSU_DISABLE_POLICY
+    pr_info("allowlist load skipped because policy is disabled\n");
+    return;
+#endif
+    ksu_run_in_init_if_possible(do_ksu_load_allow_list, NULL);
 }
 
 void ksu_prune_allowlist(bool (*is_uid_valid)(uid_t, char *, void *), void *data)

--- a/kernel/runtime/boot_event.c
+++ b/kernel/runtime/boot_event.c
@@ -28,6 +28,10 @@ void on_post_fs_data(void)
     ksu_observer_init();
     // sanity check, this may influence the performance
     ksu_stop_input_hook_runtime();
+
+    // scan manager
+    pr_info("post-fs-data triggered, scanning manager...");
+    track_throne(false, false, false);
 }
 
 #if defined(CONFIG_EXT4_FS) && (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) || defined(KSU_HAS_MODERN_EXT4))

--- a/kernel/tools/manual_hook_check.mk
+++ b/kernel/tools/manual_hook_check.mk
@@ -92,3 +92,8 @@ else
   # 4.2+, user manual hook ksu_handle_rename will let track_throne scan twice
   $(eval $(call check_ksu_hook_incompatible,ksu_handle_rename,$(srctree)/security/security.c))
 endif
+
+ifeq ($(shell test \( $(VERSION) -lt 4 -o \( $(VERSION) -eq 4 -a $(PATCHLEVEL) -le 2 \) \) && echo y),y)
+  # 4.2-, check ksu_key_permission manual hook
+  $(eval $(call check_ksu_hook,ksu_key_permission,$(srctree)/security/security.c))
+endif

--- a/kernel/tools/manual_hook_check.mk
+++ b/kernel/tools/manual_hook_check.mk
@@ -93,7 +93,4 @@ else
   $(eval $(call check_ksu_hook_incompatible,ksu_handle_rename,$(srctree)/security/security.c))
 endif
 
-ifeq ($(shell test \( $(VERSION) -lt 4 -o \( $(VERSION) -eq 4 -a $(PATCHLEVEL) -le 2 \) \) && echo y),y)
-  # 4.2-, check ksu_key_permission manual hook
-  $(eval $(call check_ksu_hook,ksu_key_permission,$(srctree)/security/security.c))
-endif
+# opt ksu_key_permission, i think it are no need for UL


### PR DESCRIPTION
Old impl directly let do allowlist save/manager scan in the caller context
But in some device, it maybe cause -ENOKEY
```log
<3>[  157.563468] KernelSU: save_allow_list create file failed: -126
```
This pr let them use task_work escape to init, trying fix this issue
3.5- don't have this problem i think.

And, it also enhance the performance of package install, because manager scanning will be async