### PR TITLE
ci: let pull request checks always trigger

### DIFF
--- a/.github/workflows/build-manager.yml
+++ b/.github/workflows/build-manager.yml
@@ -14,7 +14,6 @@ on:
       - 'userspace/**'
       - 'scripts/ksubot.py'
   pull_request:
-    branches: [ "main", "dev" ]
     paths:
       - '.github/workflows/build-manager.yml'
       - '.github/workflows/build-lkm.yml'


### PR DESCRIPTION
Currently CI scripts will let PR checks won't execute when target branch isn't main/dev
This pr fixed this issue