### PR TITLE
fix(ksud): restore susfs config across boot phases

### DIFF
--- a/userspace/ksud/src/android/init_event.rs
+++ b/userspace/ksud/src/android/init_event.rs
@@ -96,6 +96,9 @@ pub fn on_post_data_fs() -> Result<()> {
         warn!("init features failed: {e}");
     }
 
+    // Load susfs config entries that must capture metadata before mounts/overlays.
+    crate::android::susfs::init_event::on_post_fs_data();
+
     #[cfg(all(target_arch = "aarch64", target_os = "android"))]
     if let Err(e) = kpm::booted_load() {
         warn!("KPM: Failed to start KPM watcher: {e}");
@@ -127,8 +130,8 @@ pub fn on_post_data_fs() -> Result<()> {
         warn!("load umount config failed: {e}");
     }
 
-    // Load susfs config
-    crate::android::susfs::init_event::on_post_fs_data();
+    // Complete susfs kstat updates after modules have been mounted.
+    crate::android::susfs::init_event::on_post_mount();
 
     run_stage("post-mount", true);
 
@@ -167,6 +170,7 @@ pub fn run_stage(stage: &str, block: bool) {
 
 pub fn on_services() {
     info!("on_services triggered!");
+    crate::android::susfs::init_event::on_services();
     run_stage("service", false);
 }
 

--- a/userspace/ksud/src/android/late_load/mod.rs
+++ b/userspace/ksud/src/android/late_load/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     android::{
         dynamic_manager, init_event,
         module::{handle_updated_modules, metamodule, prune_modules},
-        restorecon, utils,
+        restorecon, susfs, utils,
     },
     assets, defs,
 };
@@ -116,6 +116,9 @@ pub fn run(package_name: &String, kmi: Option<String>, allow_shell: bool) -> Res
         warn!("init features failed: {e}");
     }
 
+    // Late-load skips the kernel boot events, so restore susfs explicitly.
+    susfs::init_event::on_post_fs_data();
+
     // 8. Execute late-load stage scripts (blocking)
     init_event::run_stage("late-load", true);
 
@@ -133,12 +136,17 @@ pub fn run(package_name: &String, kmi: Option<String>, allow_shell: bool) -> Res
         warn!("set dynamic manager failed: {e}");
     }
 
+    susfs::init_event::on_post_mount();
+
     // 12. Execute post-mount stage scripts (blocking)
     init_event::run_stage("post-mount", true);
+
+    susfs::init_event::on_services();
 
     // 13. Execute service stage scripts (non-blocking)
     init_event::run_stage("service", false);
 
+    susfs::init_event::on_boot_completed();
     // 14. Execute boot-completed stage scripts (non-blocking)
     init_event::run_stage("boot-completed", false);
 

--- a/userspace/ksud/src/android/susfs/api/sus_kstat.rs
+++ b/userspace/ksud/src/android/susfs/api/sus_kstat.rs
@@ -135,8 +135,7 @@ where
 
     info.is_statically = false;
     info.target_ino = md.ino();
-    info.spoofed_size = md.size() as i64;
-    info.spoofed_blocks = md.blocks();
+    copy_metadata_to_sus_kstat(&mut info, &md);
     info.flags |= KstatSpoofFlags::AUTO_SPOOF.bits();
     info.err = ERR_CMD_NOT_SUPPORTED;
 

--- a/userspace/ksud/src/android/susfs/init_event.rs
+++ b/userspace/ksud/src/android/susfs/init_event.rs
@@ -1,5 +1,6 @@
 use crate::android::susfs::api;
 use crate::android::susfs::config;
+use crate::android::susfs::config::data::Data;
 use log::warn;
 
 pub fn on_boot_completed() {
@@ -7,18 +8,44 @@ pub fn on_boot_completed() {
         return;
     };
 
-    for sus_path in config.sus_path.sus_path {
-        if let Err(e) = api::add_sus_path(&api::SusPathType::Normal, &sus_path) {
+    apply_sus_paths(&config);
+    apply_sus_maps(&config);
+}
+
+pub fn on_services() {
+    let Some(config) = config::read_config() else {
+        return;
+    };
+
+    apply_sus_paths(&config);
+    apply_sus_maps(&config);
+}
+
+fn apply_sus_paths(config: &Data) {
+    for sus_path in &config.sus_path.sus_path {
+        if sus_path.trim().is_empty() {
+            continue;
+        }
+        if let Err(e) = api::add_sus_path(&api::SusPathType::Normal, sus_path) {
             warn!("failed to add sus_path '{sus_path}': {e}");
         }
     }
-    for sus_path_loop in config.sus_path.sus_path_loop {
-        if let Err(e) = api::add_sus_path(&api::SusPathType::Loop, &sus_path_loop) {
+    for sus_path_loop in &config.sus_path.sus_path_loop {
+        if sus_path_loop.trim().is_empty() {
+            continue;
+        }
+        if let Err(e) = api::add_sus_path(&api::SusPathType::Loop, sus_path_loop) {
             warn!("failed to add sus_path_loop '{sus_path_loop}': {e}");
         }
     }
-    for sus_map in config.sus_map {
-        if let Err(e) = api::add_sus_map(&sus_map) {
+}
+
+fn apply_sus_maps(config: &Data) {
+    for sus_map in &config.sus_map {
+        if sus_map.trim().is_empty() {
+            continue;
+        }
+        if let Err(e) = api::add_sus_map(sus_map.as_str()) {
             warn!("failed to add sus_map '{sus_map}': {e}");
         }
     }
@@ -47,22 +74,20 @@ pub fn on_post_fs_data() {
         warn!("failed to hide sus mnts for non su procs: {e}");
     }
 
-    for sus_kstat in config.kstat.sus_kstat {
-        if let Err(e) = api::add_sus_kstat(&sus_kstat) {
+    apply_sus_paths(&config);
+
+    for sus_kstat in &config.kstat.sus_kstat {
+        if sus_kstat.trim().is_empty() {
+            continue;
+        }
+        if let Err(e) = api::add_sus_kstat(sus_kstat.as_str()) {
             warn!("failed to add sus_kstat '{sus_kstat}': {e}");
         }
     }
-    for update_kstat in config.kstat.update_kstat {
-        if let Err(e) = api::update_sus_kstat(&update_kstat) {
-            warn!("failed to update sus_kstat '{update_kstat}': {e}");
+    for statically in &config.kstat.statically {
+        if statically.path.trim().is_empty() {
+            continue;
         }
-    }
-    for full_clone in config.kstat.full_clone {
-        if let Err(e) = api::update_sus_kstat_full_clone(&full_clone) {
-            warn!("failed to update sus_kstat_full_clone '{full_clone}': {e}");
-        }
-    }
-    for statically in config.kstat.statically {
         if let Err(e) = api::add_sus_kstat_statically(
             &statically.path,
             &statically.ino,
@@ -82,6 +107,32 @@ pub fn on_post_fs_data() {
                 "failed to add sus_kstat_statically '{}': {}",
                 statically.path, e
             );
+        }
+    }
+}
+
+pub fn on_post_mount() {
+    let Some(config) = config::read_config() else {
+        return;
+    };
+
+    apply_sus_paths(&config);
+    apply_sus_maps(&config);
+
+    for update_kstat in &config.kstat.update_kstat {
+        if update_kstat.trim().is_empty() {
+            continue;
+        }
+        if let Err(e) = api::update_sus_kstat(update_kstat.as_str()) {
+            warn!("failed to update sus_kstat '{update_kstat}': {e}");
+        }
+    }
+    for full_clone in &config.kstat.full_clone {
+        if full_clone.trim().is_empty() {
+            continue;
+        }
+        if let Err(e) = api::update_sus_kstat_full_clone(full_clone.as_str()) {
+            warn!("failed to update sus_kstat_full_clone '{full_clone}': {e}");
         }
     }
 }


### PR DESCRIPTION
Apply persisted susfs path rules during post-fs-data, post-mount, services, and boot-completed so paths are registered early enough for zygote/app startup while still retrying paths that appear later.

Restore susfs explicitly during late-load, split kstat add/update across pre-mount and post-mount phases, and populate full metadata before enabling AUTO_SPOOF in update_sus_kstat. Skip blank persisted entries and keep per-entry failures isolated so one missing path does not block the rest of the config.