### PR TITLE
ksud: remove unused Result in susfs config

### DIFF
--- a/userspace/ksud/src/android/susfs/cli.rs
+++ b/userspace/ksud/src/android/susfs/cli.rs
@@ -386,12 +386,12 @@ pub fn run_main(command: SuSFSSubCommands) -> Result<()> {
             let target_str = target.as_deref().unwrap_or("");
             match target_str {
                 "version" => {
-                    let release = config::read_config().unwrap_or_default().common.release;
+                    let release = config::read_config().common.release;
                     api::set_uname(&"default".to_string(), &release)?;
                     config::operation::del_uname_selective("version")?;
                 }
                 "release" => {
-                    let version = config::read_config().unwrap_or_default().common.version;
+                    let version = config::read_config().common.version;
                     api::set_uname(&version, &"default".to_string())?;
                     config::operation::del_uname_selective("release")?;
                 }

--- a/userspace/ksud/src/android/susfs/config/mod.rs
+++ b/userspace/ksud/src/android/susfs/config/mod.rs
@@ -31,14 +31,14 @@ fn save_config(config: &Data) {
     }
 }
 
-pub fn read_config() -> Option<Data> {
+pub fn read_config() -> Data {
     let string = match read_config_string() {
         Some(s) => s,
         None => {
             log::warn!("failed to read susfs config, will use default config");
             let config = Data::default();
             save_config(&config);
-            return Some(config);
+            return config;
         }
     };
     let mut json: Data = match serde_json::from_str(&string) {
@@ -47,14 +47,14 @@ pub fn read_config() -> Option<Data> {
             log::warn!("failed to serialize susfs config, Err: {e}, will use default config");
             let config = Data::default();
             save_config(&config);
-            return Some(config);
+            return config;
         }
     };
 
     // Normalize/migrate legacy config
-    json = normalize_legacy_config(json);
+    normalize_legacy_config(&mut json);
 
-    Some(json)
+    json
 }
 
 fn config_paths() -> [&'static str; 2] {
@@ -107,21 +107,10 @@ fn temp_config_path(path: &Path) -> PathBuf {
     path.with_file_name(file_name)
 }
 
-/// Normalize legacy configuration and apply any necessary migrations.
-/// This function checks for and corrects common configuration issues that may
-/// have existed in older versions of the susfs config file.
-fn normalize_legacy_config(config: Data) -> Data {
-    // Note: The version and release fields in susfs.json:
-    // - version: should contain kernel uname information
-    // - release: should contain kernel build time information
-    //
-    // If we detect they are swapped (old config format), we don't automatically
-    // swap them here since we don't have a reliable way to detect if they're
-    // actually swapped vs. just unusual values. The UI layer should handle
-    // the display logic appropriately by reading the correct fields.
-    //
-    // Future: If needed, add additional migration logic here for other
-    // configuration field reorganizations.
-
-    config
+/// Fuck legacy config that swapped release and version field
+fn normalize_legacy_config(config: &mut Data) {
+    if config.common.version.contains(' ') {
+        // version does not contain space, so it is a swapped config
+        std::mem::swap(&mut config.common.version, &mut config.common.release);
+    }
 }

--- a/userspace/ksud/src/android/susfs/config/operation.rs
+++ b/userspace/ksud/src/android/susfs/config/operation.rs
@@ -6,9 +6,7 @@ pub fn add_sus_path<P>(path: P)
 where
     P: AsRef<Path>,
 {
-    let Some(mut config) = read_config() else {
-        return;
-    };
+    let mut config = read_config();
     config
         .sus_path
         .sus_path
@@ -18,27 +16,21 @@ where
 }
 
 pub fn enable_avc_spoofing(enabled: u8) {
-    let Some(mut config) = read_config() else {
-        return;
-    };
+    let mut config = read_config();
     config.common.avc_spoofing = enabled == 1;
 
     save_config(&config);
 }
 
 pub fn enable_susfs_log(enabled: u8) {
-    let Some(mut config) = read_config() else {
-        return;
-    };
+    let mut config = read_config();
     config.common.enable_susfs_log = enabled == 1;
 
     save_config(&config);
 }
 
 pub fn set_hide_sus_mnts_for_non_su_procs(enabled: u8) {
-    let Some(mut config) = read_config() else {
-        return;
-    };
+    let mut config = read_config();
     config.common.hide_sus_mnts_for_non_su_procs = enabled == 1;
 
     save_config(&config);
@@ -48,9 +40,7 @@ pub fn set_uname<S>(version: &S, release: &S)
 where
     S: ToString,
 {
-    let Some(mut config) = read_config() else {
-        return;
-    };
+    let mut config = read_config();
 
     config.common.version = version.to_string();
     config.common.release = release.to_string();
@@ -62,9 +52,7 @@ pub fn add_sus_path_loop<P>(path: P)
 where
     P: AsRef<Path>,
 {
-    let Some(mut config) = read_config() else {
-        return;
-    };
+    let mut config = read_config();
     config
         .sus_path
         .sus_path_loop
@@ -77,9 +65,7 @@ pub fn add_sus_map<P>(path: P)
 where
     P: AsRef<Path>,
 {
-    let Some(mut config) = read_config() else {
-        return;
-    };
+    let mut config = read_config();
     config
         .sus_map
         .insert(path.as_ref().to_str().unwrap().to_string());
@@ -91,9 +77,7 @@ pub fn add_sus_kstat<P>(path: P)
 where
     P: AsRef<Path>,
 {
-    let Some(mut config) = read_config() else {
-        return;
-    };
+    let mut config = read_config();
     config
         .kstat
         .sus_kstat
@@ -106,9 +90,7 @@ pub fn add_sus_kstat_update<P>(path: P)
 where
     P: AsRef<Path>,
 {
-    let Some(mut config) = read_config() else {
-        return;
-    };
+    let mut config = read_config();
     config
         .kstat
         .update_kstat
@@ -121,9 +103,7 @@ pub fn add_sus_kstat_full_clone<P>(path: P)
 where
     P: AsRef<Path>,
 {
-    let Some(mut config) = read_config() else {
-        return;
-    };
+    let mut config = read_config();
     config
         .kstat
         .full_clone
@@ -148,9 +128,7 @@ pub fn add_sus_kstat_statically(
     blocks: &str,
     blksize: &str,
 ) {
-    let Some(mut config) = read_config() else {
-        return;
-    };
+    let mut config = read_config();
 
     config.kstat.statically.insert(SusKstatStatically {
         path: path.to_string(),
@@ -175,9 +153,7 @@ pub fn del_sus_path<P>(path: P)
 where
     P: AsRef<Path>,
 {
-    let Some(mut config) = read_config() else {
-        return;
-    };
+    let mut config = read_config();
     config
         .sus_path
         .sus_path
@@ -189,9 +165,7 @@ where
 use anyhow::Result;
 
 pub fn del_uname_selective(target: &str) -> Result<()> {
-    let Some(mut config) = read_config() else {
-        return Ok(());
-    };
+    let mut config = read_config();
 
     match target {
         "version" => {
@@ -223,9 +197,7 @@ pub fn del_sus_path_loop<P>(path: P)
 where
     P: AsRef<Path>,
 {
-    let Some(mut config) = read_config() else {
-        return;
-    };
+    let mut config = read_config();
     config
         .sus_path
         .sus_path_loop
@@ -238,9 +210,7 @@ pub fn del_sus_map<P>(path: P)
 where
     P: AsRef<Path>,
 {
-    let Some(mut config) = read_config() else {
-        return;
-    };
+    let mut config = read_config();
     config.sus_map.remove(path.as_ref().to_str().unwrap());
 
     save_config(&config);
@@ -250,9 +220,7 @@ pub fn del_sus_kstat<P>(path: P)
 where
     P: AsRef<Path>,
 {
-    let Some(mut config) = read_config() else {
-        return;
-    };
+    let mut config = read_config();
     config
         .kstat
         .sus_kstat
@@ -265,9 +233,7 @@ pub fn del_sus_kstat_update<P>(path: P)
 where
     P: AsRef<Path>,
 {
-    let Some(mut config) = read_config() else {
-        return;
-    };
+    let mut config = read_config();
     config
         .kstat
         .update_kstat
@@ -280,9 +246,7 @@ pub fn del_sus_kstat_full_clone<P>(path: P)
 where
     P: AsRef<Path>,
 {
-    let Some(mut config) = read_config() else {
-        return;
-    };
+    let mut config = read_config();
     config
         .kstat
         .full_clone
@@ -307,9 +271,7 @@ pub fn del_sus_kstat_statically(
     blocks: &str,
     blksize: &str,
 ) {
-    let Some(mut config) = read_config() else {
-        return;
-    };
+    let mut config = read_config();
 
     config.kstat.statically.remove(&SusKstatStatically {
         path: path.to_string(),

--- a/userspace/ksud/src/android/susfs/init_event.rs
+++ b/userspace/ksud/src/android/susfs/init_event.rs
@@ -4,18 +4,14 @@ use crate::android::susfs::config::data::Data;
 use log::warn;
 
 pub fn on_boot_completed() {
-    let Some(config) = config::read_config() else {
-        return;
-    };
+    let config = config::read_config();
 
     apply_sus_paths(&config);
     apply_sus_maps(&config);
 }
 
 pub fn on_services() {
-    let Some(_config) = config::read_config() else {
-        return;
-    };
+    // let config = config::read_config();
 
     // apply_sus_paths(&config);
     // apply_sus_maps(&config);
@@ -54,9 +50,7 @@ fn apply_sus_maps(config: &Data) {
 }
 
 pub fn on_post_fs_data() {
-    let Some(config) = config::read_config() else {
-        return;
-    };
+    let config = config::read_config();
 
     if let Err(e) = api::set_uname(&config.common.version, &config.common.release) {
         warn!("failed to set uname: {e}");
@@ -114,9 +108,7 @@ pub fn on_post_fs_data() {
 }
 
 pub fn on_post_mount() {
-    let Some(config) = config::read_config() else {
-        return;
-    };
+    let config = config::read_config();
 
     // apply_sus_paths(&config);
     // apply_sus_maps(&config);

--- a/userspace/ksud/src/android/susfs/slot_info.rs
+++ b/userspace/ksud/src/android/susfs/slot_info.rs
@@ -1,6 +1,7 @@
 use std::{
     io::{Cursor, Read},
     path::{Path, PathBuf},
+    sync::atomic::{AtomicBool, Ordering},
 };
 
 use android_bootimg::parser::BootImage;
@@ -23,9 +24,7 @@ const LZ4_FRAME_MAGIC_1: [u8; 4] = [0x03, 0x21, 0x4c, 0x18];
 const LZ4_FRAME_MAGIC_2: [u8; 4] = [0x04, 0x22, 0x4d, 0x18];
 
 // Global verbose flag for debug output
-thread_local! {
-    static VERBOSE: std::cell::RefCell<bool> = const { std::cell::RefCell::new(false) };
-}
+static VERBOSE: AtomicBool = AtomicBool::new(false);
 
 #[derive(Serialize)]
 struct SlotInfo {
@@ -64,11 +63,11 @@ impl std::fmt::Display for CompressionFormat {
 }
 
 fn set_verbose(verbose: bool) {
-    VERBOSE.with(|v| *v.borrow_mut() = verbose);
+    VERBOSE.store(verbose, Ordering::Relaxed);
 }
 
 fn is_verbose() -> bool {
-    VERBOSE.with(|v| *v.borrow())
+    VERBOSE.load(Ordering::Relaxed)
 }
 
 fn debug_log(msg: &str) {


### PR DESCRIPTION
Additionally made slot_info.rs use `AtomicBool` instead to avoid clippy warning