### PR TITLE
manager: update Anykernel3 source string

### DIFF
--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -322,7 +322,7 @@
     <string name="horizon_unknown_error">Unknown error</string>
     <string name="flash_failed_message">Flash failed</string>
     <string name="Lkm_install_methods">LKM repair/installation</string>
-    <string name="GKI_install_methods">Flashing AnyKernel3</string>
+    <string name="GKI_install_methods">Flash AnyKernel3</string>
     <string name="kernel_version_log">Kernel version：%1$s</string>
     <string name="tool_version_log">Using the patching tool：%1$s</string>
     <string name="configuration">Configure</string>


### PR DESCRIPTION
This PR replaces the English source string:

* From: `Flashing Anykernel3`
* To: `Flash Anykernel3`

Only the English source string in `manager/app/src/main/res/values/strings.xml` is changed.

The zh-rTW translation change from the previous PR has been removed, as requested.

#251 