### PR TITLE
Fix: Restore 'Hide Tag Row' switch state after app restart

### DIFF
--- a/manager/app/src/main/java/com/resukisu/resukisu/ui/viewmodel/ModuleViewModel.kt
+++ b/manager/app/src/main/java/com/resukisu/resukisu/ui/viewmodel/ModuleViewModel.kt
@@ -48,6 +48,16 @@ class ModuleViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(ModuleUiState())
     val uiState: StateFlow<ModuleUiState> = _uiState.asStateFlow()
 
+    private fun applyUserSettings() {
+        val prefs = ksuApp.appPreferences
+        _uiState.update {
+            it.copy(
+                showMoreModuleInfo = prefs.getBoolean("show_more_module_info", false),
+                isHideTagRow = prefs.getBoolean("is_hide_tag_row", false),
+            )
+        }
+    }
+
     fun loadSize(dirId: String) = viewModelScope.launch(Dispatchers.IO) {
         val size = formatFileSize(
             try {
@@ -185,7 +195,9 @@ class ModuleViewModel : ViewModel() {
     ) {
         viewModelScope.launch(Dispatchers.IO) {
             _uiState.update { it.copy(isRefreshing = true) }
-
+         
+            applyUserSettings()
+            
             val oldModuleList = modules
             val start = SystemClock.elapsedRealtime()
 


### PR DESCRIPTION
## Summary
Fixed a bug where the "Hide Tag Row" switch in the Module settings
would reset to "off" after restarting the app, even though the actual
feature remained enabled.

## Root Cause
`ModuleViewModel` never read the persisted preference
`is_hide_tag_row` during initialization. The UI state always defaulted
to `false`, while the feature logic used the SharedPreferences value
directly. This caused a mismatch between the switch UI and the actual
functionality after app restart.

## Changes
- Added `applyUserSettings()` in `ModuleViewModel` to load
  `show_more_module_info` and `is_hide_tag_row` from SharedPreferences
- Called `applyUserSettings()` inside `fetchModuleList()` to apply the
  saved settings during refresh and initial load
- The existing `updateBooleanPref()` logic remains unchanged

## Testing
- Toggle the "Hide Tag Row" switch → feature works as expected
- Force-stop and restart the app → switch UI correctly restores to the
  previous state
- Verified that the same fix applies to `show_more_module_info` as well

## Affected Files
- `ModuleViewModel.kt`