### PR TITLE
Fix module settings persistence and Add silent refresh on resume and …

### DIFF
--- a/manager/app/src/main/java/com/resukisu/resukisu/ui/MainActivity.kt
+++ b/manager/app/src/main/java/com/resukisu/resukisu/ui/MainActivity.kt
@@ -160,11 +160,31 @@ class MainActivity : ComponentActivity() {
         // Initialize theme settings.
         ThemeUtils.initializeThemeSettings(this, settingsViewModel)
     }
-
+    
+    // 新增刷新方法代码开始
+    private fun refreshDataOnResume() {
+        // 1. 主页：静默刷新（与下拉刷新逻辑一致，仅无动画）
+        if (::homeViewModel.isInitialized) {
+            homeViewModel.refreshDataSilently(applicationContext)
+        }
+        // 2. 模块页面：静默刷新（manualRefresh = true 完整检查更新，silent = true 无动画）
+        if (::moduleViewModel.isInitialized) {
+            moduleViewModel.fetchModuleList(manualRefresh = true, silent = true)
+        }
+        // 3. 超级用户页面：静默刷新
+        if (::superUserViewModel.isInitialized) {
+            lifecycleScope.launch {
+                superUserViewModel.fetchAppList(silent = true)
+            }
+        }
+    }
+    // 新增刷新方法代码结束
+    
     override fun onResume() {
         try {
             super.onResume()
             ThemeUtils.onActivityResume()
+            refreshDataOnResume()  //新增刷新方法调用
         } catch (e: Exception) {
             e.printStackTrace()
         }

--- a/manager/app/src/main/java/com/resukisu/resukisu/ui/screen/AppProfile.kt
+++ b/manager/app/src/main/java/com/resukisu/resukisu/ui/screen/AppProfile.kt
@@ -86,7 +86,9 @@ import com.resukisu.resukisu.ui.util.setSepolicy
 import com.resukisu.resukisu.ui.viewmodel.SuperUserViewModel
 import com.resukisu.resukisu.ui.viewmodel.getTemplateInfoById
 import kotlinx.coroutines.launch
-
+import androidx.lifecycle.ViewModelProvider
+import com.resukisu.resukisu.ksuApp
+import com.resukisu.resukisu.ui.viewmodel.HomeViewModel
 /**
  * @author weishu
  * @date 2023/5/16.
@@ -190,6 +192,17 @@ fun AppProfileScreen(
                         snackBarHost.showSnackbar(failToUpdateAppProfile.format(appGroup.uid))
                     } else {
                         profile = it
+                        // ✅ 新增：刷新超级用户列表和主页数据
+                        try {
+                            // 刷新超级用户列表（静默）
+                            ViewModelProvider(ksuApp)[SuperUserViewModel::class.java]
+                                .fetchAppList(silent = true)
+                            // 刷新主页数据（静默）
+                            ViewModelProvider(ksuApp)[HomeViewModel::class.java]
+                                .refreshDataSilently(ksuApp)
+                        } catch (e: Exception) {
+                            // 忽略
+                        }
                     }
                 }
             },

--- a/manager/app/src/main/java/com/resukisu/resukisu/ui/viewmodel/HomeViewModel.kt
+++ b/manager/app/src/main/java/com/resukisu/resukisu/ui/viewmodel/HomeViewModel.kt
@@ -398,6 +398,44 @@ class HomeViewModel : ViewModel() {
         return job
     }
 
+/**
+ * 静默刷新主页数据
+ * 与 refreshData(refreshUI = true) 逻辑完全一致，仅移除动画
+ * 用于从后台返回或数据变更时的自动刷新场景
+ */
+    fun refreshDataSilently(context: Context) {
+        // 1. 检查更新（强制检查，与下拉刷新一致）
+        refreshManagerUpdates(context, force = true)
+
+        // 2. 直接执行刷新（不检查 isInitialDataLoaded，与下拉刷新一致）
+        val job = viewModelScope.launch(Dispatchers.IO) {
+            try {
+                loadingJobs.forEach { it.cancel() }
+                loadingJobs.clear()
+
+                // 3. 刷新用户设置（与下拉刷新一致）
+                val userSettings = async { applyUserSettings(context) }
+
+                // 4. 强制刷新核心数据和扩展数据（与下拉刷新一致）
+                val coreJob = loadCoreData(force = true)
+                val extendedJob = loadExtendedData(context, force = true)
+
+                coreJob?.join()
+                extendedJob?.join()
+                userSettings.join()
+            } finally {
+                _uiState.update {
+                    it.copy(
+                        isInitialDataLoaded = true,
+                        // 注意：不设置 isRefreshing，保持 false（无动画）
+                    )
+                }
+            }
+        }
+
+        dataLoadJob = job
+    }
+
     private fun applyUserSettings(context: Context) {
         val settingsPrefs = context.appPreferences
         _uiState.update {

--- a/manager/app/src/main/java/com/resukisu/resukisu/ui/viewmodel/ModuleViewModel.kt
+++ b/manager/app/src/main/java/com/resukisu/resukisu/ui/viewmodel/ModuleViewModel.kt
@@ -47,6 +47,17 @@ class ModuleViewModel : ViewModel() {
     private var modules: List<ModuleInfo> = emptyList()
     private val _uiState = MutableStateFlow(ModuleUiState())
     val uiState: StateFlow<ModuleUiState> = _uiState.asStateFlow()
+    
+    // 添加模块相关设置持久化方法applyUserSettings
+    private fun applyUserSettings() {
+        val prefs = ksuApp.appPreferences
+        _uiState.update {
+            it.copy(
+                showMoreModuleInfo = prefs.getBoolean("show_more_module_info", false),
+                isHideTagRow = prefs.getBoolean("is_hide_tag_row", false),
+            )
+        }
+    }
 
     fun loadSize(dirId: String) = viewModelScope.launch(Dispatchers.IO) {
         val size = formatFileSize(
@@ -181,11 +192,17 @@ class ModuleViewModel : ViewModel() {
 
     fun fetchModuleList(
         manualRefresh: Boolean = false,
+        silent: Boolean = false,    // 添加控制参数
         callBack: () -> Unit = {},
     ) {
         viewModelScope.launch(Dispatchers.IO) {
-            _uiState.update { it.copy(isRefreshing = true) }
-
+            // 添加判断，静默时跳过动画
+            if (!silent) {
+                _uiState.update { it.copy(isRefreshing = true) }
+            }
+         
+            applyUserSettings()  // 添加读取用户设置数据
+            
             val oldModuleList = modules
             val start = SystemClock.elapsedRealtime()
 

--- a/manager/app/src/main/java/com/resukisu/resukisu/ui/viewmodel/SuperUserViewModel.kt
+++ b/manager/app/src/main/java/com/resukisu/resukisu/ui/viewmodel/SuperUserViewModel.kt
@@ -274,14 +274,20 @@ class SuperUserViewModel : ViewModel() {
         }
     }
 
-    suspend fun fetchAppList() {
+    suspend fun fetchAppList(silent: Boolean = false) {
         if (_uiState.value.isRefreshing) return
 
-        _uiState.update { it.copy(isRefreshing = true, loadingProgress = 0f) }
+        // 增加判断静默时不触发动画
+        if (!silent) {
+            _uiState.update { it.copy(isRefreshing = true, loadingProgress = 0f) }
+        }
 
         try {
             val binder = connectKsuService() ?: run {
-                _uiState.update { it.copy(isRefreshing = false) }
+                // 增加判断静默时不触发动画
+                if (!silent) {
+                    _uiState.update { it.copy(isRefreshing = false) }
+                }
                 return
             }
 
@@ -310,7 +316,10 @@ class SuperUserViewModel : ViewModel() {
                         }
                     }
                     start += page.size
-                    _uiState.update { it.copy(loadingProgress = start.toFloat() / total) }
+                    // 增加判断静默时不触发动画
+                    if (!silent) {
+                        _uiState.update { it.copy(loadingProgress = start.toFloat() / total) }
+                    }
                 }
 
                 appListMutex.withLock {
@@ -336,7 +345,10 @@ class SuperUserViewModel : ViewModel() {
         } catch (e: Exception) {
             Log.e(TAG, "Error refresh app list", e)
         } finally {
-            _uiState.update { it.copy(isRefreshing = false) }
+            // 增加判断静默时不触发动画
+	    if (!silent) {
+                _uiState.update { it.copy(isRefreshing = false) }
+	    }
             stopKsuService()
         }
     }


### PR DESCRIPTION
…views

Introduce silent data refresh behavior to keep UI up-to-date without triggering refresh animations. Changes include:

- MainActivity: added refreshDataOnResume() and call in onResume() to silently refresh Home, Module and SuperUser viewmodels when the activity resumes.
- HomeViewModel: added refreshDataSilently(context) which mirrors the existing refresh logic but avoids setting isRefreshing (no animation).
- ModuleViewModel: added applyUserSettings() to load persisted module settings and extended fetchModuleList(manualRefresh, silent) to skip isRefreshing when silent; applyUserSettings() is invoked during fetch.
- SuperUserViewModel: fetchAppList(silent: Boolean) now supports silent mode to avoid toggling isRefreshing and loadingProgress when silent.
- AppProfile: after successful profile update, trigger silent refreshes for SuperUserViewModel and HomeViewModel via ViewModelProvider(ksuApp) (errors ignored).

Purpose: perform background/return-from-background updates and refresh data after profile changes without showing pull-to-refresh animations, and persist/load module-specific UI settings.