### PR TITLE
manager: fix stray quote corrupting saved app profile templates

### DIFF
--- a/manager/app/src/main/java/com/resukisu/resukisu/ui/util/KsuCli.kt
+++ b/manager/app/src/main/java/com/resukisu/resukisu/ui/util/KsuCli.kt
@@ -533,7 +533,7 @@ fun getAppProfileTemplate(id: String): String {
 fun setAppProfileTemplate(id: String, template: String): Boolean {
     val shell = getRootShell()
     val escapedTemplate = template.replace("\"", "\\\"")
-    val cmd = """${getKsuDaemonPath()} profile set-template "$id" "$escapedTemplate'""""
+    val cmd = """${getKsuDaemonPath()} profile set-template "$id" "$escapedTemplate""""
     return shell.newJob().add(cmd)
         .to(ArrayList(), null).exec().isSuccess
 }


### PR DESCRIPTION
`setAppProfileTemplate` in `KsuCli.kt` builds the command like this:

```kotlin
val cmd = """${getKsuDaemonPath()} profile set-template "$id" "$escapedTemplate'""""
```

There's a stray `'` right before the closing `"` (`"$escapedTemplate'"`). Inside double quotes that single quote is a literal, so it isn't quoting anything — it gets handed to `ksud` as part of the template argument, and `set_template` then writes it verbatim to `PROFILE_TEMPLATE_DIR/<id>`. The result is that every template saved through the manager gains a trailing `'`.

Fix is just to remove the stray quote. The sibling helpers (`getAppProfileTemplate`, `deleteAppProfileTemplate`) already quote correctly.