### PR TITLE
kernel: check allocations in add_filename_trans (>= 5.7 path)

### DIFF
--- a/kernel/selinux/sepolicy.c
+++ b/kernel/selinux/sepolicy.c
@@ -627,9 +627,24 @@ static bool add_filename_trans(struct policydb *db, const char *s, const char *t
 
     if (trans == NULL) {
         trans = (struct filename_trans_datum *)kcalloc(1, sizeof(*trans), GFP_KERNEL);
+        if (!trans) {
+            pr_err("add_filename_trans: Failed to alloc datum\n");
+            return false;
+        }
         struct filename_trans_key *new_key = (struct filename_trans_key *)kzalloc(sizeof(*new_key), GFP_KERNEL);
+        if (!new_key) {
+            pr_err("add_filename_trans: Failed to alloc new_key\n");
+            kfree(trans);
+            return false;
+        }
         *new_key = key;
         new_key->name = kstrdup(key.name, GFP_KERNEL);
+        if (!new_key->name) {
+            pr_err("add_filename_trans: Failed to dup name\n");
+            kfree(new_key);
+            kfree(trans);
+            return false;
+        }
         trans->next = last;
         trans->otype = def->value;
         hashtab_insert(&db->filename_trans, new_key, trans, filenametr_key_params);


### PR DESCRIPTION
In `sepolicy.c`, the `LINUX_VERSION_CODE >= KERNEL_VERSION(5, 7, 0)` branch of `add_filename_trans()` does:

```c
trans = kcalloc(1, sizeof(*trans), GFP_KERNEL);
struct filename_trans_key *new_key = kzalloc(sizeof(*new_key), GFP_KERNEL);
*new_key = key;                        // deref, no NULL check
new_key->name = kstrdup(key.name, ..); // unchecked
trans->next = last;                    // deref, no NULL check
```

None of `trans`, `new_key`, or the `kstrdup` result are checked, so an allocation failure is a NULL dereference / kernel panic.

Interestingly the legacy `< 5.7.0` branch just below already guards its `kcalloc`/`kzalloc`, so the modern path was simply missed. This adds the same checks there and frees the partial allocations on the way out. No change on the success path.