### PR TITLE
ksud: don't panic on a broken zip in get_zip_uncompressed_size

### DIFF
--- a/userspace/ksud/src/android/utils.rs
+++ b/userspace/ksud/src/android/utils.rs
@@ -124,9 +124,9 @@ pub fn is_safe_mode() -> bool {
 
 pub fn get_zip_uncompressed_size(zip_path: &str) -> Result<u64> {
     let mut zip = zip::ZipArchive::new(std::fs::File::open(zip_path)?)?;
-    let total: u64 = (0..zip.len())
-        .map(|i| zip.by_index(i).unwrap().size())
-        .sum();
+    let total = (0..zip.len())
+        .map(|i| zip.by_index(i).map(|f| f.size()))
+        .sum::<zip::result::ZipResult<u64>>()?;
     Ok(total)
 }
 


### PR DESCRIPTION
`get_zip_uncompressed_size` walks the archive with `by_index(i).unwrap()`. If any entry can't be read the `unwrap()` panics and takes the whole ksud process down. It's reachable from `module install` (a truncated/corrupt zip), where you'd want a clean error instead of a panic.

The function already returns `Result<u64>`, so propagate with `?`:

```rust
let mut total: u64 = 0;
for i in 0..zip.len() {
    total += zip.by_index(i)?.size();
}
Ok(total)
```

No change for valid archives.