### PR TITLE
ksud: validate resetprop --timeout to avoid a panic

### DIFF
--- a/userspace/ksud/src/android/resetprop.rs
+++ b/userspace/ksud/src/android/resetprop.rs
@@ -162,7 +162,11 @@ fn execute(cli: &Args) -> Result<()> {
     // -w: wait mode
     if cli.wait {
         let name = cli.name().context("--wait requires a property name")?;
-        let timeout = cli.timeout.map(Duration::from_secs_f64);
+        let timeout = cli
+            .timeout
+            .map(Duration::try_from_secs_f64)
+            .transpose()
+            .map_err(|_| anyhow::anyhow!("invalid --timeout value"))?;
         let ok = rp
             .wait(name, cli.value().map(std::string::String::as_str), timeout)
             .context("wait failed")?;


### PR DESCRIPTION
`Duration::from_secs_f64` panics on negative, NaN or out-of-range input, and the `--timeout` value is parsed straight from the command line and fed into it:

```rust
let timeout = cli.timeout.map(Duration::from_secs_f64);
```

So `resetprop -w --timeout -1 sys.boot_completed` panics instead of reporting an error. Switched to the fallible `try_from_secs_f64` and mapped the error into a normal message, matching how the rest of the arg handling reports bad input.