### PR TITLE
manager: guard parseKernelVersion against non-Int version fields

### DIFF
--- a/manager/app/src/main/java/com/resukisu/resukisu/Kernels.kt
+++ b/manager/app/src/main/java/com/resukisu/resukisu/Kernels.kt
@@ -18,11 +18,15 @@ data class KernelVersion(val major: Int, val patchLevel: Int, val subLevel: Int)
 
 fun parseKernelVersion(version: String): KernelVersion {
     val find = "(\\d+)\\.(\\d+)\\.(\\d+)".toRegex().find(version)
-    return if (find != null) {
-        KernelVersion(find.groupValues[1].toInt(), find.groupValues[2].toInt(), find.groupValues[3].toInt())
-    } else {
-        KernelVersion(-1, -1, -1)
+    if (find != null) {
+        val major = find.groupValues[1].toIntOrNull()
+        val patchLevel = find.groupValues[2].toIntOrNull()
+        val subLevel = find.groupValues[3].toIntOrNull()
+        if (major != null && patchLevel != null && subLevel != null) {
+            return KernelVersion(major, patchLevel, subLevel)
+        }
     }
+    return KernelVersion(-1, -1, -1)
 }
 
 fun getKernelVersion(): KernelVersion {


### PR DESCRIPTION
`parseKernelVersion` pulls three numeric groups out of the version string and calls `.toInt()` on each:

```kotlin
KernelVersion(find.groupValues[1].toInt(), find.groupValues[2].toInt(), find.groupValues[3].toInt())
```

The input is `Os.uname().release`, which isn't guaranteed sane. If any captured field is too large for an `Int`, `toInt()` throws `NumberFormatException` and crashes, even though the function already has a `(-1, -1, -1)` sentinel for the "no match" case.

Switched to `toIntOrNull()` and fall back to that same sentinel when a field can't be parsed, so an odd release string reads as an unknown version instead of crashing.