### PR TITLE
kernel: check kernel_read() results when verifying the APK signing block

### DIFF
--- a/kernel/manager/apk_sign.c
+++ b/kernel/manager/apk_sign.c
@@ -102,17 +102,23 @@ static bool check_block(struct file *fp, u32 *size4, loff_t *pos, u32 *offset, u
 #define CERT_MAX_LENGTH 1024
     char cert[CERT_MAX_LENGTH];
 
-    ksu_kernel_read_compat(fp, size4, 0x4, pos); // signer-sequence length
-    ksu_kernel_read_compat(fp, size4, 0x4, pos); // signer length
-    ksu_kernel_read_compat(fp, size4, 0x4, pos); // signed data length
+    if (ksu_kernel_read_compat(fp, size4, 0x4, pos) != 0x4) // signer-sequence length
+        return false;
+    if (ksu_kernel_read_compat(fp, size4, 0x4, pos) != 0x4) // signer length
+        return false;
+    if (ksu_kernel_read_compat(fp, size4, 0x4, pos) != 0x4) // signed data length
+        return false;
     *offset += 0x4 * 3;
 
-    ksu_kernel_read_compat(fp, size4, 0x4, pos); // digests-sequence length
+    if (ksu_kernel_read_compat(fp, size4, 0x4, pos) != 0x4) // digests-sequence length
+        return false;
     *pos += *size4;
     *offset += 0x4 + *size4;
 
-    ksu_kernel_read_compat(fp, size4, 0x4, pos); // certificates length
-    ksu_kernel_read_compat(fp, size4, 0x4, pos); // certificate length
+    if (ksu_kernel_read_compat(fp, size4, 0x4, pos) != 0x4) // certificates length
+        return false;
+    if (ksu_kernel_read_compat(fp, size4, 0x4, pos) != 0x4) // certificate length
+        return false;
     *offset += 0x4 * 2;
 
     if (*size4 > CERT_MAX_LENGTH) {
@@ -252,17 +258,25 @@ static __always_inline bool check_v2_signature(char *path, u8 *signature_index)
 
     pos += 12;
     // offset
-    ksu_kernel_read_compat(fp, &size4, 0x4, &pos);
+    if (ksu_kernel_read_compat(fp, &size4, 0x4, &pos) != 0x4) {
+        goto clean;
+    }
     pos = size4 - 0x18;
 
-    ksu_kernel_read_compat(fp, &size8, 0x8, &pos);
-    ksu_kernel_read_compat(fp, buffer, 0x10, &pos);
+    if (ksu_kernel_read_compat(fp, &size8, 0x8, &pos) != 0x8) {
+        goto clean;
+    }
+    if (ksu_kernel_read_compat(fp, buffer, 0x10, &pos) != 0x10) {
+        goto clean;
+    }
     if (strcmp((char *)buffer, "APK Sig Block 42")) {
         goto clean;
     }
 
     pos = size4 - (size8 + 0x8);
-    ksu_kernel_read_compat(fp, &size_of_block, 0x8, &pos);
+    if (ksu_kernel_read_compat(fp, &size_of_block, 0x8, &pos) != 0x8) {
+        goto clean;
+    }
     if (size_of_block != size8) {
         goto clean;
     }
@@ -271,12 +285,17 @@ static __always_inline bool check_v2_signature(char *path, u8 *signature_index)
     while (loop_count++ < 10) {
         uint32_t id;
         uint32_t offset;
-        ksu_kernel_read_compat(fp, &size8, 0x8,
-                               &pos); // sequence length
+        if (ksu_kernel_read_compat(fp, &size8, 0x8, &pos) != 0x8) { // sequence length
+            v2_signing_valid = false;
+            goto clean;
+        }
         if (size8 == size_of_block) {
             break;
         }
-        ksu_kernel_read_compat(fp, &id, 0x4, &pos); // id
+        if (ksu_kernel_read_compat(fp, &id, 0x4, &pos) != 0x4) { // id
+            v2_signing_valid = false;
+            goto clean;
+        }
         offset = 4;
         if (id == 0x7109871au) {
             v2_signing_blocks++;


### PR DESCRIPTION
`check_block()` and `check_v2_signature()` in `apk_sign.c` read the APK v2 signing block field by field with `ksu_kernel_read_compat()`. The certificate read is already length-checked, but the surrounding length fields aren't — on a truncated or malformed APK the offset arithmetic runs on whatever happened to be on the stack.

It's bounded by the `CERT_MAX_LENGTH` guard so this isn't a memory-safety hole, but working off stale values on the manager-verification path isn't ideal.

This adds the length checks:
- in `check_block`, the six field reads now bail out (`return false`) on a short read;
- in `check_v2_signature`, the reads after the EOCD scan `goto clean`, and the two reads inside the id-block loop invalidate the result first (so the post-loop block-count / v1 checks aren't skipped).

A properly signed manager APK reads every field back in full, so nothing changes for the normal case. The EOCD-search loop is intentionally left untouched since it already tolerates short reads via its `n == i` check.