### PR TITLE
kernel: null-check tts allocation in track_throne

### DIFF
--- a/kernel/manager/throne_tracker.c
+++ b/kernel/manager/throne_tracker.c
@@ -423,6 +423,10 @@ out:
 void track_throne(unsigned int flags)
 {
     struct track_throne_struct *tts = kzalloc(sizeof(struct track_throne_struct), GFP_KERNEL);
+    if (!tts) {
+        pr_err("track_throne: failed to allocate track_throne_struct\n");
+        return;
+    }
     tts->flags = flags;
 
     if (flags & TRACK_THRONE_FORCE_SYNCHRONOUS) {


### PR DESCRIPTION
`track_throne()` allocates the `track_throne_struct` that gets passed to the worker, but immediately writes `tts->flags` without checking whether the `kzalloc` actually succeeded:

```c
struct track_throne_struct *tts = kzalloc(sizeof(struct track_throne_struct), GFP_KERNEL);
tts->flags = flags;
```

If the allocation fails that's a NULL dereference and a panic. Skipping one throne update when we're out of memory is harmless, so just log and return.