### PR TITLE
kernel: null-check last_app_id_map allocation in do_track_throne

### DIFF
--- a/kernel/manager/throne_tracker.c
+++ b/kernel/manager/throne_tracker.c
@@ -281,6 +281,11 @@ void do_track_throne(void *data)
     mutex_lock(&app_list_lock);
     if (unlikely(!last_app_id_map)) {
         last_app_id_map = bitmap_zalloc(MAX_APP_ID, GFP_KERNEL);
+        if (!last_app_id_map) {
+            mutex_unlock(&app_list_lock);
+            pr_err("track_throne: failed to allocate last_app_id_map\n");
+            return;
+        }
     }
     mutex_unlock(&app_list_lock);
 


### PR DESCRIPTION
`last_app_id_map` is allocated lazily on the first run of `do_track_throne()`:

```c
if (unlikely(!last_app_id_map)) {
    last_app_id_map = bitmap_zalloc(MAX_APP_ID, GFP_KERNEL);
}
```

The result isn't checked, but it's later passed to `bitmap_andnot(diff_map, last_app_id_map, ...)` and `bitmap_copy(last_app_id_map, ...)`. If that first allocation fails we end up operating on a NULL bitmap and crash. Bail out when it fails — this happens before `curr_app_id_map`/`diff_map` are allocated, so there's nothing to clean up.