### PR TITLE
ksud: validate lengths when loading module config

### DIFF
--- a/userspace/ksud/src/android/module/module_config.rs
+++ b/userspace/ksud/src/android/module/module_config.rs
@@ -152,7 +152,11 @@ pub fn load_config(module_id: &str, config_type: ConfigType) -> Result<HashMap<S
     let mut count_buf = [0u8; 4];
     file.read_exact(&mut count_buf)
         .with_context(|| "Failed to read count")?;
-    let count = u32::from_le_bytes(count_buf);
+    let count = u32::from_le_bytes(count_buf) as usize;
+
+    if count > MAX_CONFIG_COUNT {
+        bail!("Too many config entries: {count} (max: {MAX_CONFIG_COUNT})");
+    }
 
     // Read entries
     let mut config = HashMap::new();
@@ -162,6 +166,10 @@ pub fn load_config(module_id: &str, config_type: ConfigType) -> Result<HashMap<S
         file.read_exact(&mut key_len_buf)
             .with_context(|| format!("Failed to read key length for entry {i}"))?;
         let key_len = u32::from_le_bytes(key_len_buf) as usize;
+
+        if key_len > MAX_CONFIG_KEY_LEN {
+            bail!("Config key too long for entry {i}: {key_len} bytes (max: {MAX_CONFIG_KEY_LEN})");
+        }
 
         // Read key data
         let mut key_buf = vec![0u8; key_len];
@@ -175,6 +183,12 @@ pub fn load_config(module_id: &str, config_type: ConfigType) -> Result<HashMap<S
         file.read_exact(&mut value_len_buf)
             .with_context(|| format!("Failed to read value length for entry {i}"))?;
         let value_len = u32::from_le_bytes(value_len_buf) as usize;
+
+        if value_len > MAX_CONFIG_VALUE_LEN {
+            bail!(
+                "Config value too long for entry {i}: {value_len} bytes (max: {MAX_CONFIG_VALUE_LEN})"
+            );
+        }
 
         // Read value data
         let mut value_buf = vec![0u8; value_len];


### PR DESCRIPTION
`save_config()` validates the entry count and every key/value against the limits declared at the top of the file:

```rust
pub const MAX_CONFIG_KEY_LEN: usize = 256;
pub const MAX_CONFIG_VALUE_LEN: usize = 1024 * 1024;
pub const MAX_CONFIG_COUNT: usize = 32;
```

`load_config()` checks none of them. It reads `count`, `key_len` and `value_len` straight out of the file and uses them as-is:

```rust
let key_len = u32::from_le_bytes(key_len_buf) as usize;
let mut key_buf = vec![0u8; key_len];
```

They're u32 fields, so a damaged config file can ask for an allocation of up to 4GB. The `read_exact()` on the next line would fail, but the allocation happens first, so ksud aborts instead of reporting an error.

This applies the same three limits on the read path. Files written by `save_config()` are unaffected, since it can't emit values above the limits to begin with.