### PR TITLE
manager: wait for the backup process before reading its exit code

### DIFF
--- a/manager/app/src/main/java/com/resukisu/resukisu/ui/util/module/ModuleModify.kt
+++ b/manager/app/src/main/java/com/resukisu/resukisu/ui/util/module/ModuleModify.kt
@@ -74,6 +74,9 @@ object ModuleModify {
                 }
 
                 val error = BufferedReader(InputStreamReader(process.errorStream)).readText()
+
+                process.waitFor()
+
                 if (process.exitValue() != 0) {
                     throw IOException(context.getString(R.string.command_execution_failed, error))
                 }


### PR DESCRIPTION
`ModuleModify.backupAllowlist()` reads the exit code without waiting for the process:

```kotlin
val process = Runtime.getRuntime().exec(arrayOf("su", "-c", "cat $allowlistPath"))
context.contentResolver.openOutputStream(uri)?.use { output ->
    process.inputStream.copyTo(output)
}

val error = BufferedReader(InputStreamReader(process.errorStream)).readText()
if (process.exitValue() != 0) {          // <- no waitFor()
```

`Process.exitValue()` throws `IllegalThreadStateException` when the process hasn't exited yet. That exception lands in the `catch (e: Exception)` at the bottom, so the user gets "allowlist backup failed" even though the file was copied out correctly.

Reaching EOF on stdout doesn't guarantee the child has been reaped, so the failure is timing-dependent, which matches it working most of the time.

`restoreAllowlist()` immediately below already does `process.waitFor()` before checking `exitValue()` — this just makes the backup path do the same.