### PR TITLE
kernel: revert creds when save allowlist failed

### DIFF
--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -468,6 +468,7 @@ void do_persistent_allow_list(void *unused)
     fp = filp_open(KERNEL_SU_ALLOWLIST, O_WRONLY | O_CREAT | O_TRUNC, 0644);
     if (IS_ERR(fp)) {
         pr_err("save_allow_list create file failed: %ld\n", PTR_ERR(fp));
+        revert_creds(saved);
         return;
     }
 


### PR DESCRIPTION
We lost that... cause when allowlist save failed, we will let system crash 
Especially happen in 4.9 devices

Close #275