### PR TITLE
kernel: decouple susfs proc-umounted marking from umount_modules toggle

### DIFF
--- a/kernel/feature/kernel_umount.c
+++ b/kernel/feature/kernel_umount.c
@@ -144,8 +144,12 @@ int ksu_handle_umount(uid_t old_uid, uid_t new_uid)
         return 0;
     }
 
-    if (!ksu_uid_should_umount(new_uid) && !is_isolated_process(new_uid)) {
+    if (ksu_uid_is_root_granted(new_uid)) {
         return 0;
+    }
+
+    if (!ksu_uid_should_umount(new_uid) && !is_isolated_process(new_uid)) {
+        goto skip_umount_task;
     }
 
     // no need to check zygote here, because we already check it in the setuid call.

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -346,6 +346,35 @@ bool ksu_uid_should_umount(uid_t uid)
 #endif
 }
 
+bool ksu_uid_is_root_granted(uid_t uid)
+{
+    struct app_profile *profile;
+    bool res;
+
+    if (unlikely(ksu_is_manager_uid(uid))) {
+        return true;
+    }
+    if (unlikely(uid == WEBVIEW_ZYGOTE_UID)) {
+        return true;
+    }
+#ifdef CONFIG_KSU_DISABLE_POLICY
+    return __ksu_is_allow_uid(uid);
+#else
+    rcu_read_lock();
+    profile = ksu_get_app_profile(uid);
+    if (!profile) {
+        res = false;
+    } else {
+        res = profile->allow_su;
+    }
+    rcu_read_unlock();
+
+    if (profile)
+        ksu_put_app_profile(profile);
+    return res;
+#endif
+}
+
 void ksu_put_app_profile(struct app_profile *profile)
 {
     struct perm_data *p = container_of(profile, struct perm_data, profile);

--- a/kernel/policy/allowlist.h
+++ b/kernel/policy/allowlist.h
@@ -40,6 +40,9 @@ void ksu_put_app_profile(struct app_profile *);
 int ksu_set_app_profile(struct app_profile *);
 
 bool ksu_uid_should_umount(uid_t uid);
+// Whether uid is genuinely granted su (or is manager/webview zygote),
+// independent of the umount_modules toggle.
+bool ksu_uid_is_root_granted(uid_t uid);
 struct root_profile *ksu_get_root_profile(uid_t uid);
 // only used to put the root_profile returned by ksu_get_root_profile
 void ksu_put_root_profile(struct root_profile *);


### PR DESCRIPTION
susfs's TIF_PROC_UMOUNTED marking was gated on ksu_uid_should_umount(), which conflates two unrelated things: whether a uid is genuinely granted su, and whether the (non-root) profile wants module bind-mounts physically removed via umount_modules. When umount_modules is off, ksu_handle_umount() returned before ever marking the process, so sus_path/sus_path_loop hiding never applied to it.

Add ksu_uid_is_root_granted() to answer only the su-grant question, and use it as the sole exclusion check in ksu_handle_umount(). All other paths now goto the existing skip_umount_task label instead of returning early, so the susfs marking stays the single, last thing the function does - always after try_umount() completes, never before it.