### PR TITLE
ksud: avoid reboot supercall in app seccomp

### DIFF
--- a/kernel/include/arch.h
+++ b/kernel/include/arch.h
@@ -21,6 +21,7 @@
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 16, 0)
 #define REBOOT_SYMBOL "__arm64_sys_reboot"
+#define PRCTL_SYMBOL "__arm64_sys_prctl"
 #define SYS_READ_SYMBOL "__arm64_sys_read"
 #define SYS_EXECVE_SYMBOL "__arm64_sys_execve"
 #define SYS_SETNS_SYMBOL __arm64_sys_setns
@@ -29,6 +30,7 @@
 #define SYS_FSTAT_SYMBOL "__arm64_sys_newfstat"
 #else
 #define REBOOT_SYMBOL "sys_reboot"
+#define PRCTL_SYMBOL "sys_prctl"
 #define SYS_READ_SYMBOL "sys_read"
 #define SYS_EXECVE_SYMBOL "sys_execve"
 #define SYS_SETNS_SYMBOL sys_setns
@@ -54,12 +56,14 @@
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 16, 0)
 #define REBOOT_SYMBOL "__x64_sys_reboot"
+#define PRCTL_SYMBOL "__x64_sys_prctl"
 #define SYS_READ_SYMBOL "__x64_sys_read"
 #define SYS_EXECVE_SYMBOL "__x64_sys_execve"
 #define SYS_SETNS_SYMBOL __x64_sys_setns
 #define SYS_FSTAT_SYMBOL "__x64_sys_newfstat"
 #else
 #define REBOOT_SYMBOL "sys_reboot"
+#define PRCTL_SYMBOL "sys_prctl"
 #define SYS_READ_SYMBOL "sys_read"
 #define SYS_EXECVE_SYMBOL "sys_execve"
 #define SYS_SETNS_SYMBOL sys_setns

--- a/kernel/supercall/supercall.c
+++ b/kernel/supercall/supercall.c
@@ -129,8 +129,9 @@ int ksu_handle_sys_reboot(int magic1, int magic2, unsigned int cmd, void __user 
 }
 
 #ifdef CONFIG_KSU_TRACEPOINT_HOOK
-// Reboot hook for installing fd
-static int reboot_handler_pre(struct kprobe *p, struct pt_regs *regs)
+// The original reboot(2) carrier is retained for existing ksud binaries.
+// New userspace uses prctl(2), which Android app seccomp profiles permit.
+static int supercall_handler_pre(struct kprobe *p, struct pt_regs *regs)
 {
     struct pt_regs *real_regs = PT_REAL_REGS(regs);
     int magic1 = (int)PT_REGS_PARM1(real_regs);
@@ -144,8 +145,15 @@ static int reboot_handler_pre(struct kprobe *p, struct pt_regs *regs)
 
 static struct kprobe reboot_kp = {
     .symbol_name = REBOOT_SYMBOL,
-    .pre_handler = reboot_handler_pre,
+    .pre_handler = supercall_handler_pre,
 };
+
+static struct kprobe prctl_kp = {
+    .symbol_name = PRCTL_SYMBOL,
+    .pre_handler = supercall_handler_pre,
+};
+
+static bool prctl_kp_registered;
 #endif
 
 void __init ksu_supercalls_init(void)
@@ -161,12 +169,22 @@ void __init ksu_supercalls_init(void)
     } else {
         pr_info("reboot kprobe registered successfully\n");
     }
+
+    rc = register_kprobe(&prctl_kp);
+    if (rc) {
+        pr_err("prctl kprobe failed: %d\n", rc);
+    } else {
+        pr_info("prctl kprobe registered successfully\n");
+        prctl_kp_registered = true;
+    }
 #endif
 }
 
 void __exit ksu_supercalls_exit(void)
 {
 #ifdef CONFIG_KSU_TRACEPOINT_HOOK
+    if (prctl_kp_registered)
+        unregister_kprobe(&prctl_kp);
     unregister_kprobe(&reboot_kp);
 #endif
     ksu_supercall_cleanup_state();

--- a/userspace/ksud/src/android/ksucalls.rs
+++ b/userspace/ksud/src/android/ksucalls.rs
@@ -33,8 +33,12 @@ fn init_driver_fd() -> Option<RawFd> {
     if fd.is_none() {
         let mut fd = -1;
         unsafe {
+            // Android app seccomp profiles reject reboot(2), which was the
+            // original KernelSU supercall carrier. prctl(2) is available to
+            // ordinary app processes and has the same four argument slots
+            // needed by the LKM transport.
             libc::syscall(
-                libc::SYS_reboot,
+                libc::SYS_prctl,
                 uapi::KSU_INSTALL_MAGIC1_RUST,
                 uapi::KSU_INSTALL_MAGIC2_RUST,
                 0,


### PR DESCRIPTION
#### Motivation: 
The manager’s `debug su` crashed before reaching KSU because it used `SYS_reboot` to obtain the driver FD. The patch changes new `ksud` builds to use `SYS_prctl`, while the LKM registers a matching `prctl` kprobe and retains the existing reboot hook for backward compatibility.

#### Testing
- Verified with formatting, diff checks, and a ksud compile check.
- Device:
  Oneplus 15 (CPH2747)
  OxygenOS 16.0.10.500, Kernel 6.12.23

#### AI Disclosure
GPT-5.6-Terra was used to author this code.