### PR TITLE
ksud: opt in to manager registration before restart

### DIFF
--- a/userspace/ksud/src/android/cli.rs
+++ b/userspace/ksud/src/android/cli.rs
@@ -79,6 +79,10 @@ enum Commands {
         /// manager package name
         #[arg(long, default_value_t = String::from("com.resukisu.resukisu"))]
         package_name: String,
+
+        /// Register the installed manager APK before restarting it
+        #[arg(long)]
+        register_manager: bool,
     },
 
     /// Manage auto apply user custom umount configs
@@ -724,15 +728,22 @@ pub fn run() -> Result<()> {
             post_magica,
             kmi,
             package_name,
+            register_manager,
         } => {
             if let Some(port) = magica {
-                return crate::android::late_load::magica::run(port, &package_name, allow_shell)
-                    .map_err(|e| {
-                        error!("Error running magica: {e}");
-                        e
-                    });
+                return crate::android::late_load::magica::run(
+                    port,
+                    &package_name,
+                    allow_shell,
+                    register_manager,
+                )
+                .map_err(|e| {
+                    error!("Error running magica: {e}");
+                    e
+                });
             }
-            let result = crate::android::late_load::run(&package_name, kmi, allow_shell);
+            let result =
+                crate::android::late_load::run(&package_name, kmi, allow_shell, register_manager);
             if post_magica {
                 info!("Restoring adb properties (post-magica cleanup)...");
                 if let Err(e) = crate::android::late_load::magica::disable_adb_root() {
@@ -894,16 +905,7 @@ pub fn run() -> Result<()> {
                     }
                     Ok(())
                 }
-                DynamicManagerOp::SetApk { apk } => {
-                    let sign = apk_sign::get_apk_signature(&apk)?;
-
-                    let bytes = sign.1.as_bytes();
-
-                    let mut hash = [0u8; 64];
-                    hash.copy_from_slice(bytes);
-
-                    dynamic_manager::set(sign.0, hash)
-                }
+                DynamicManagerOp::SetApk { apk } => dynamic_manager::set_apk(&apk),
                 DynamicManagerOp::Clear => dynamic_manager::clear(),
             },
             Kernel::NotifyModuleMounted => {

--- a/userspace/ksud/src/android/dynamic_manager.rs
+++ b/userspace/ksud/src/android/dynamic_manager.rs
@@ -3,7 +3,7 @@ use std::fs;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use crate::{android::ksucalls, defs};
+use crate::{android::ksucalls, apk_sign, defs};
 
 #[derive(Debug, Deserialize, Serialize)]
 struct Config {
@@ -74,4 +74,13 @@ pub fn set(size: u32, hash: [u8; 64]) -> Result<()> {
 
     ksucalls::dynamic_manager_set_synchronous(size, hash)?;
     Ok(())
+}
+
+pub fn set_apk(apk: &str) -> Result<()> {
+    let (size, hash) = apk_sign::get_apk_signature(apk)?;
+    let hash: [u8; 64] = hash
+        .as_bytes()
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("dynamic manager signature has an invalid length"))?;
+    set(size, hash)
 }

--- a/userspace/ksud/src/android/late_load/magica.rs
+++ b/userspace/ksud/src/android/late_load/magica.rs
@@ -138,7 +138,12 @@ fn connect_to_device(port: u16) -> Result<ADBTcpDevice> {
     bail!("Failed to connect to ADB device after {MAX_RETRIES} attempts")
 }
 
-pub fn run(port: u16, package_name: &String, allow_shell: bool) -> Result<()> {
+pub fn run(
+    port: u16,
+    package_name: &String,
+    allow_shell: bool,
+    register_manager: bool,
+) -> Result<()> {
     enable_adb_root(port)?;
 
     let mut device = connect_to_device(port)?;
@@ -150,11 +155,17 @@ pub fn run(port: u16, package_name: &String, allow_shell: bool) -> Result<()> {
     // 1. Load kernelsu.ko, enforce SELinux, run stage scripts
     // 2. Restore adb properties (disable adb root/tcp mode)
     let allow_shell_arg = if allow_shell { " --allow-shell" } else { "" };
+    let register_manager_arg = if register_manager {
+        " --register-manager"
+    } else {
+        ""
+    };
     let cmd = format!(
-        "{} late-load --post-magica --package-name {}{}",
+        "{} late-load --post-magica --package-name {}{}{}",
         self_path.display(),
         package_name,
-        allow_shell_arg
+        allow_shell_arg,
+        register_manager_arg,
     );
     info!("Executing '{cmd}' via adb shell...");
     let mut stdout = Vec::new();

--- a/userspace/ksud/src/android/late_load/mod.rs
+++ b/userspace/ksud/src/android/late_load/mod.rs
@@ -44,7 +44,37 @@ fn dump_process_info(label: &str) {
     );
 }
 
-pub fn run(package_name: &String, kmi: Option<String>, allow_shell: bool) -> Result<()> {
+fn manager_base_apk_path(pm_output: &str) -> Option<String> {
+    let paths = pm_output
+        .lines()
+        .filter_map(|line| line.strip_prefix("package:"));
+    let paths: Vec<_> = paths.collect();
+    paths
+        .iter()
+        .find(|path| path.ends_with("/base.apk"))
+        .or_else(|| paths.first())
+        .map(|path| (*path).to_owned())
+}
+
+fn manager_base_apk(package_name: &str) -> Result<String> {
+    let output = Command::new("pm")
+        .args(["path", package_name])
+        .output()
+        .with_context(|| format!("failed to query manager package {package_name}"))?;
+    if !output.status.success() {
+        anyhow::bail!("pm path {package_name} exited with {}", output.status);
+    }
+
+    let output = String::from_utf8(output.stdout).context("manager package path was not UTF-8")?;
+    manager_base_apk_path(&output).context("manager package has no APK path")
+}
+
+pub fn run(
+    package_name: &String,
+    kmi: Option<String>,
+    allow_shell: bool,
+    register_manager: bool,
+) -> Result<()> {
     utils::daemonize(false)?;
     info!("late-load command triggered!");
     dump_process_info("late-load start");
@@ -88,6 +118,22 @@ pub fn run(package_name: &String, kmi: Option<String>, allow_shell: bool) -> Res
     }
 
     utils::install(None).context("Failed to install ksud")?;
+
+    if register_manager {
+        // Register the manager before its restart below. That restart is the point
+        // at which KernelSU injects the per-process driver fd, avoiding a fallback
+        // supercall from the app's seccomp-confined process.
+        match manager_base_apk(package_name) {
+            Ok(apk) => {
+                if let Err(e) = dynamic_manager::set_apk(&apk) {
+                    warn!("set dynamic manager for {package_name} failed: {e}");
+                } else {
+                    info!("registered dynamic manager {package_name}");
+                }
+            }
+            Err(e) => warn!("find manager APK for {package_name} failed: {e}"),
+        }
+    }
 
     // 5. Handle module updates
     if let Err(e) = handle_updated_modules() {
@@ -152,4 +198,21 @@ pub fn run(package_name: &String, kmi: Option<String>, allow_shell: bool) -> Res
         .status();
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::manager_base_apk_path;
+
+    #[test]
+    fn manager_base_apk_path_prefers_base_apk_over_splits() {
+        let output = concat!(
+            "package:/data/app/example/split_config.arm64_v8a.apk\n",
+            "package:/data/app/example/base.apk\n",
+        );
+        assert_eq!(
+            manager_base_apk_path(output).as_deref(),
+            Some("/data/app/example/base.apk"),
+        );
+    }
 }


### PR DESCRIPTION
#### Motivation

Before this change, a late-loaded KernelSU module could restart the Manager before its APK was registered as the dynamic manager. The restarted app then had no injected KernelSU driver FD and had to use a fallback connection path, which may be unavailable from its seccomp-confined process. As a result, Manager-provided operations such as `debug su` could not establish a KernelSU session.

#### Changes

Add an opt-in `ksud late-load --register-manager` flag.

When requested, `ksud` resolves the Manager’s `base.apk`, registers its signing identity with the dynamic-manager interface, and only then restarts the Manager. This ensures the restarted Manager receives its KernelSU driver FD instead of needing a fallback connection path that may be blocked by app seccomp.

The default late-load behavior is unchanged. Magica forwarding is supported, and the implementation prefers `base.apk` over split APKs.

#### Testing
- Oneplus 15 (CPH2747) / OP611FL1, OxygenOS 16.0.10.500 (Android 16; API 36), Kernel 6.12.23
  - `late-load --register-manager --kmi android16-6.12`
  - KernelSU module loaded successfully; Manager package helper was replaced and invoked with the new option.
- Rust: 
  ```bash
  cargo fmt --check
  cargo check --manifest-path userspace/ksud/Cargo.toml
  cargo build --manifest-path userspace/ksud/Cargo.toml --target aarch64-linux-android --release
  ```

#### AI Disclosure
GPT-5.6-Terra was used to author this code.