### PR TITLE
ksud: call post_ota() only once after OTA flash

### DIFF
--- a/userspace/ksud/src/boot_patch.rs
+++ b/userspace/ksud/src/boot_patch.rs
@@ -817,9 +817,6 @@ pub fn patch(args: BootPatchArgs) -> Result<()> {
             if ota {
                 post_ota()?;
             }
-            if ota {
-                post_ota()?;
-            }
         }
 
         #[cfg(target_os = "android")]


### PR DESCRIPTION
## Summary

`boot_patch` with `--flash --ota` called `post_ota()` twice back-to-back after flashing the new boot image.

The second call repeats `bootctl hal-info`, `get-current-slot`, `set-active-boot-slot`, and rewrites the identical `post_ota.sh`. Besides wasting process spawns and file I/O, a transient failure in the redundant call would turn an already-successful flash into an error.

This PR removes the duplicate call, so `post_ota()` runs exactly once.

## Verification

- `cargo fmt --check --manifest-path userspace/ksud/Cargo.toml` passes
- Change is a pure deletion inside the existing `if ota` block (Android-target code)