### PR TITLE
ksud: reuse ZIP archive and validate module IDs

### DIFF
--- a/userspace/ksud/Cargo.lock
+++ b/userspace/ksud/Cargo.lock
@@ -214,16 +214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
-dependencies = [
- "memchr",
- "serde_core",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,19 +743,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
-name = "globset"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "goblin"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,22 +822,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "ignore"
-version = "0.4.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
-dependencies = [
- "crossbeam-deque",
- "globset",
- "log",
- "memchr",
- "regex-automata",
- "same-file",
- "walkdir",
- "winapi-util",
 ]
 
 [[package]]
@@ -1077,7 +1038,6 @@ dependencies = [
  "tempfile",
  "which",
  "zip 8.6.0",
- "zip-extensions",
 ]
 
 [[package]]
@@ -2239,16 +2199,6 @@ dependencies = [
  "time",
  "typed-path",
  "zopfli",
-]
-
-[[package]]
-name = "zip-extensions"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285251480403d7097be64d5c33518279ecf5f816d5ebe403c476e45ea16c5628"
-dependencies = [
- "ignore",
- "zip 8.6.0",
 ]
 
 [[package]]

--- a/userspace/ksud/Cargo.toml
+++ b/userspace/ksud/Cargo.toml
@@ -43,11 +43,6 @@ zip = { version = "8", features = [
     "lzma",
     "xz",
 ], default-features = false }
-zip-extensions = { version = "0.14", features = [
-    "deflate",
-    "lzma",
-    "xz",
-], default-features = false }
 java-properties = { git = "https://github.com/Kernel-SU/java-properties.git", branch = "master", default-features = false }
 serde_json = "1"
 encoding_rs = "0.8"

--- a/userspace/ksud/src/android/module/mod.rs
+++ b/userspace/ksud/src/android/module/mod.rs
@@ -7,19 +7,10 @@ use std::{
     collections::{BTreeMap, HashMap},
     env::var as env_var,
     fs::{File, Permissions, canonicalize, copy, remove_dir_all, rename, set_permissions},
-    io::{Cursor, Write},
+    io::{Cursor, Read, Seek, Write},
     path::{Path, PathBuf},
     process::Command,
-    str::FromStr,
 };
-
-use anyhow::{Context, Result, anyhow, bail, ensure};
-use const_format::concatcp;
-use is_executable::is_executable;
-use java_properties::PropertiesIter;
-use log::{debug, error, info, warn};
-use regex_lite::Regex;
-use zip_extensions::zip_extract::zip_extract_file_to_memory;
 
 use crate::{
     android::{
@@ -35,6 +26,12 @@ use crate::{
     assets, banner, defs,
     defs::{MODULE_DIR, MODULE_UPDATE_DIR, UPDATE_FILE_NAME},
 };
+use anyhow::{Context, Result, anyhow, bail, ensure};
+use const_format::concatcp;
+use is_executable::is_executable;
+use java_properties::PropertiesIter;
+use log::{debug, error, info, warn};
+use regex_lite::Regex;
 
 const INSTALLER_CONTENT: &str = include_str!("./installer.sh");
 const INSTALL_MODULE_SCRIPT: &str = concatcp!(
@@ -525,6 +522,24 @@ pub fn handle_updated_modules() -> Result<()> {
     Ok(())
 }
 
+fn read_module_prop_from_archive<R>(
+    archive: &mut zip::ZipArchive<R>,
+) -> Result<HashMap<String, String>>
+where
+    R: Read + Seek,
+{
+    let mut buffer = Vec::new();
+    archive.by_name("module.prop")?.read_to_end(&mut buffer)?;
+
+    let mut module_prop = HashMap::new();
+    PropertiesIter::new_with_encoding(Cursor::new(buffer), encoding_rs::UTF_8).read_into(
+        |k, v| {
+            module_prop.insert(k, v);
+        },
+    )?;
+    Ok(module_prop)
+}
+
 fn install_module_to_system(zip: &str) -> Result<()> {
     ensure_boot_completed()?;
 
@@ -537,19 +552,12 @@ fn install_module_to_system(zip: &str) -> Result<()> {
     ensure_dir_exists(defs::WORKING_DIR).with_context(|| "Failed to create working dir")?;
     ensure_dir_exists(defs::BINARY_DIR).with_context(|| "Failed to create bin dir")?;
 
-    // read the module_id from zip, if failed it will return early.
-    let mut buffer: Vec<u8> = Vec::new();
-    let entry_path = PathBuf::from_str("module.prop")?;
-    let zip_path = PathBuf::from_str(zip)?;
+    // Open the archive once and reuse it for metadata reads, size calculation, and extraction.
+    let zip_path = PathBuf::from(zip);
     let zip_path = zip_path.canonicalize()?;
-    zip_extract_file_to_memory(&zip_path, &entry_path, &mut buffer)?;
-
-    let mut module_prop = HashMap::new();
-    PropertiesIter::new_with_encoding(Cursor::new(buffer), encoding_rs::UTF_8).read_into(
-        |k, v| {
-            module_prop.insert(k, v);
-        },
-    )?;
+    let file = File::open(&zip_path)?;
+    let mut archive = zip::ZipArchive::new(file)?;
+    let module_prop = read_module_prop_from_archive(&mut archive)?;
     info!("module prop: {module_prop:?}");
 
     let Some(module_id) = module_prop.get("id") else {
@@ -612,7 +620,7 @@ fn install_module_to_system(zip: &str) -> Result<()> {
         }
     }
 
-    let zip_uncompressed_size = get_zip_uncompressed_size(zip)?;
+    let zip_uncompressed_size = get_zip_uncompressed_size(&mut archive)?;
     info!(
         "zip uncompressed size: {}",
         humansize::format_size(zip_uncompressed_size, humansize::DECIMAL)
@@ -633,8 +641,6 @@ fn install_module_to_system(zip: &str) -> Result<()> {
 
     // Extract zip to target directory
     println!("- Extracting module files");
-    let file = File::open(zip)?;
-    let mut archive = zip::ZipArchive::new(file)?;
     archive.extract(&updated_dir)?;
 
     // Set permission and selinux context for $MOD/system

--- a/userspace/ksud/src/android/module/mod.rs
+++ b/userspace/ksud/src/android/module/mod.rs
@@ -758,6 +758,8 @@ pub fn enable_module(id: &str) -> Result<()> {
 }
 
 pub fn disable_module(id: &str) -> Result<()> {
+    validate_module_id(id)?;
+
     let module_path = Path::new(defs::MODULE_DIR).join(id);
     ensure!(module_path.exists(), "Module {id} not found");
 

--- a/userspace/ksud/src/android/utils.rs
+++ b/userspace/ksud/src/android/utils.rs
@@ -5,7 +5,7 @@ use std::{
     fs::{File, OpenOptions, Permissions, create_dir_all, remove_file, set_permissions, write},
     io::{
         ErrorKind::{AlreadyExists, NotFound},
-        Write,
+        Read, Seek, Write,
     },
     path::{Path, PathBuf},
     process::Command,
@@ -163,8 +163,11 @@ pub fn is_safe_mode() -> bool {
     safemode
 }
 
-pub fn get_zip_uncompressed_size(zip_path: &str) -> Result<u64> {
-    let mut zip = zip::ZipArchive::new(std::fs::File::open(zip_path)?)?;
+/// Calculate the total uncompressed size of all entries in an open archive.
+pub fn get_zip_uncompressed_size<R>(zip: &mut zip::ZipArchive<R>) -> Result<u64>
+where
+    R: Read + Seek,
+{
     let total = (0..zip.len())
         .map(|i| zip.by_index(i).map(|f| f.size()))
         .sum::<zip::result::ZipResult<u64>>()?;


### PR DESCRIPTION
## Summary

- Reuse the opened ZIP archive throughout module installation instead of reopening the package for metadata, size calculation, and extraction.
- Validate the module ID before disabling a module to prevent path traversal and malformed module paths.

## Why

The installation path was reopening the same package multiple times, and the disable path accepted an unchecked module ID before joining it to the module directory.

## Impact

- Module installation keeps a single ZIP archive open for the operation.
- Invalid module IDs are rejected before filesystem access.
- No tests were added per request.

## Checks

- cargo fmt --check --manifest-path userspace/ksud/Cargo.toml
- git diff --check