### PR TITLE
kernel: restore legacy fake policy rwlock initialization

### DIFF
--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -517,6 +517,8 @@ static int ksu_selinux_hide_enable()
         return -ENOMEM;
     }
 
+    rwlock_init(&fake_state.ss->policy_rwlock);
+
     // In normal android
     // Only set selinux policy once
     // So let's just hardcode to 1 to avoid avdSeqNo detect


### PR DESCRIPTION
The legacy fake selinux_ss path passes fake_state to SELinux service helpers that acquire policy_rwlock. Initialize the dynamically allocated lock before exposing the fake state to those helpers.

This initialization existed before 17416418 but was dropped while reworking sidtab ownership. A zeroed lock happens to match the raw unlocked representation on some non-debug configurations, but debug/lockdep-enabled kernels require the lock metadata to be initialized as well.

Tested by building the Samsung A325N Linux 4.14 kernel with the legacy KSU_COMPAT_USE_SELINUX_STATE path.