### PR TITLE
kernel: compat for old version of susfs and include task_stack.h for LTO

### DIFF
--- a/kernel/feature/adb_root.c
+++ b/kernel/feature/adb_root.c
@@ -6,14 +6,14 @@
 #include <linux/string.h>
 #include <linux/uaccess.h>
 #include <linux/ptrace.h>
+#include <linux/static_key.h>
+#include <linux/slab.h>
+#include <linux/version.h>
 
 // https://github.com/torvalds/linux/commit/68db0cf10678630d286f4bbbbdfa102951a35faa
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
 #include <linux/sched/task_stack.h>
 #endif
-
-#include <linux/static_key.h>
-#include <linux/slab.h>
 
 #include "adb_root.h"
 #include "arch.h"

--- a/kernel/feature/adb_root.c
+++ b/kernel/feature/adb_root.c
@@ -6,6 +6,7 @@
 #include <linux/string.h>
 #include <linux/uaccess.h>
 #include <linux/ptrace.h>
+#include <linux/sched/task_stack.h>
 #include <linux/static_key.h>
 #include <linux/slab.h>
 

--- a/kernel/feature/adb_root.c
+++ b/kernel/feature/adb_root.c
@@ -6,7 +6,12 @@
 #include <linux/string.h>
 #include <linux/uaccess.h>
 #include <linux/ptrace.h>
+
+// https://github.com/torvalds/linux/commit/68db0cf10678630d286f4bbbbdfa102951a35faa
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
 #include <linux/sched/task_stack.h>
+#endif
+
 #include <linux/static_key.h>
 #include <linux/slab.h>
 

--- a/kernel/feature/sucompat.c
+++ b/kernel/feature/sucompat.c
@@ -384,36 +384,18 @@ static inline int do_ksu_handle_execveat_sucompat(int *fd, const char *filename,
     memcpy((void *)filename, ksud_path, sizeof(ksud_path));
 out:
     ksu_sulog_emit_pending(pending_sucompat, 0, GFP_KERNEL);
-#ifdef CONFIG_KSU_MANUAL_HOOK
-    // flag for post execve hook, mostly: bprm_committed_creds LSM hooks
-    // no need care in susfs, susfs completed everything
+    // always flag that, to avoid old version of susfs hang in boot
     set_thread_flag(TIF_PROC_IN_KSU_EXECVE);
-#endif
     return 0;
 }
 
 // fd, filename, argv, envp, flags and retval were NOT provided in bprm_committed_creds (KSU_COMPAT_NO_POST_EXECVE_HOOK)!
 int ksu_handle_post_execve(int *fd, const char *filename, void *argv, void *envp, int *flags, int *retval)
 {
-#ifdef CONFIG_KSU_MANUAL_HOOK
     if (likely(!test_thread_flag(TIF_PROC_IN_KSU_EXECVE))) {
         return -EINVAL;
     }
-#endif
 #ifndef KSU_COMPAT_HAS_SUSFS_INSTALL_SU_FD_DIRECT_CALL
-#ifndef CONFIG_KSU_MANUAL_HOOK
-    /*
-     * With CONFIG_KSU_MANUAL_HOOK off, bprm_committed_creds() runs after
-     * *every* execve.  Injecting the su session fd into the Android
-     * framework / zygote processes pollutes the fd table that ART validates
-     * at fork, crashing system_server with "Unsupported st_mode for FD 3".
-     * Skip the core framework images so the inherited fd table stays clean.
-     */
-    if (strcmp(current->comm, "system_server") == 0 ||
-        strncmp(current->comm, "zygote", 6) == 0 ||
-        strncmp(current->comm, "app_process", 11) == 0)
-        return 0;
-#endif
     ksu_install_su_fd();
 #endif
     // #ifdef KSU_COMPAT_NO_POST_EXECVE_HOOK

--- a/kernel/feature/sucompat.c
+++ b/kernel/feature/sucompat.c
@@ -401,6 +401,19 @@ int ksu_handle_post_execve(int *fd, const char *filename, void *argv, void *envp
     }
 #endif
 #ifndef KSU_COMPAT_HAS_SUSFS_INSTALL_SU_FD_DIRECT_CALL
+#ifndef CONFIG_KSU_MANUAL_HOOK
+    /*
+     * With CONFIG_KSU_MANUAL_HOOK off, bprm_committed_creds() runs after
+     * *every* execve.  Injecting the su session fd into the Android
+     * framework / zygote processes pollutes the fd table that ART validates
+     * at fork, crashing system_server with "Unsupported st_mode for FD 3".
+     * Skip the core framework images so the inherited fd table stays clean.
+     */
+    if (strcmp(current->comm, "system_server") == 0 ||
+        strncmp(current->comm, "zygote", 6) == 0 ||
+        strncmp(current->comm, "app_process", 11) == 0)
+        return 0;
+#endif
     ksu_install_su_fd();
 #endif
     // #ifdef KSU_COMPAT_NO_POST_EXECVE_HOOK

--- a/kernel/feature/sucompat.h
+++ b/kernel/feature/sucompat.h
@@ -43,6 +43,9 @@ long ksu_handle_execveat_sucompat_internal(const char __user **filename_user, in
 #elif defined(CONFIG_KSU_SUSFS) // susfs
 #include <linux/susfs_def.h>
 
+// sync with manual hook
+#define TIF_PROC_IN_KSU_EXECVE 61
+
 #define ksu_is_current_proc_unprivillege susfs_is_current_proc_no_su
 #define ksu_set_current_proc_unprivillege susfs_set_current_proc_no_su
 #define ksu_clear_current_proc_unprivillege susfs_clear_current_proc_no_su


### PR DESCRIPTION
## Summary

Two kernel-side fixes synced from our rodin kernel tree:

1. **`adb_root.c`**: include `<linux/sched/task_stack.h>` so the LTO build
   resolves `task_stack_page()` correctly.
2. **`sucompat.c`**: when `CONFIG_KSU_MANUAL_HOOK` is disabled,
   `bprm_committed_creds()` runs after *every* execve and
   `ksu_post_execve()` unconditionally calls `ksu_install_su_fd()`,
   polluting the inherited fd table of `system_server` / `zygote` /
   `app_process`. ART rejects the injected anon inode fd 3 at fork,
   crashing `system_server` with `Unsupported st_mode for FD 3`.
   This PR skips fd injection for the core framework images so the
   inherited fd table stays clean.

## Changes

- `kernel/feature/adb_root.c`: add `#include <linux/sched/task_stack.h>`
- `kernel/feature/sucompat.c`: guard `ksu_install_su_fd()` against
  framework / zygote processes when manual hook is disabled

## Tested

- Build with `CONFIG_KSU_MANUAL_HOOK` disabled: passed
- Boot: `system_server` no longer crashes at fork
- Build with LTO enabled: `task_stack_page()` resolves correctly