### PR TITLE
manager: fix LayoutNode crash when toggling root access in SuperUser page

### DIFF
--- a/manager/app/src/main/java/com/resukisu/resukisu/ui/screen/main/SuperUserPage.kt
+++ b/manager/app/src/main/java/com/resukisu/resukisu/ui/screen/main/SuperUserPage.kt
@@ -73,7 +73,6 @@ import com.resukisu.resukisu.ui.component.settings.lazySegmentColumn
 import com.resukisu.resukisu.ui.navigation.LocalNavigator
 import com.resukisu.resukisu.ui.navigation.Route
 import com.resukisu.resukisu.ui.screen.LabelText
-import com.resukisu.resukisu.ui.theme.blurSource
 import com.resukisu.resukisu.ui.util.LocalSnackbarHost
 import com.resukisu.resukisu.ui.util.adaptiveScaffoldWindowInsets
 import com.resukisu.resukisu.ui.util.showReplacingSnackbar
@@ -290,8 +289,7 @@ private fun SuperUserContent(
     if (uiState.appGroupList.isEmpty()) {
         Box(
             modifier = Modifier
-                .fillMaxSize()
-                .blurSource(),
+                .fillMaxSize(),
             contentAlignment = Alignment.Center
         ) {
             if (uiState.isRefreshing && uiState.search.isEmpty()) {
@@ -330,8 +328,7 @@ private fun SuperUserContent(
         onRefresh = { viewModel.dispatch(SuperUserUiAction.Refresh) },
         isRefreshing = uiState.isRefreshing,
         modifier = Modifier
-            .fillMaxSize()
-            .blurSource(),
+            .fillMaxSize(),
         indicator = {
             PullToRefreshDefaults.LoadingIndicator(
                 modifier = Modifier


### PR DESCRIPTION
## Problem

The manager app crashes with `IllegalArgumentException: LayoutNode not found in RectList` when toggling root access for an application on the SuperUser page.

**Steps to reproduce:**
1. Open SuperUser page
2. Tap an app to open its profile
3. Toggle root access on/off
4. Navigate back to SuperUser page
5. App force closes during list refresh

## Root Cause

`SuperUserContent` applies `.blurSource()` to the `PullToRefreshBox` and the empty-state `Box`. These containers wrap the `LazyColumn` whose items change when the app list refreshes after toggling root access.

`layerBackdrop()` inside `blurSource()` captures a snapshot of the layout tree. When `LazyColumn` items change during recomposition, the backdrop RectList still references stale LayoutNodes, causing `dispatchDraw` to throw.

## Fix

Remove `.blurSource()` from the two dynamic containers in `SuperUserContent`. The blur backdrop from `MainScreen.blurSource()` still covers the entire pager content, so visual blur is preserved.